### PR TITLE
fixes #1083: TypeMetadata constructor copies fieldNames

### DIFF
--- a/src/main/java/datawave/query/util/TypeMetadata.java
+++ b/src/main/java/datawave/query/util/TypeMetadata.java
@@ -45,6 +45,7 @@ public class TypeMetadata implements Serializable {
             this.typeMetadata.put(entry.getKey(), HashMultimap.create(entry.getValue()));
         }
         this.ingestTypes.addAll(in.ingestTypes);
+        this.fieldNames.addAll(in.fieldNames);
     }
     
     public void addForAllIngestTypes(Map<String,Set<String>> map) {


### PR DESCRIPTION
see https://github.com/NationalSecurityAgency/datawave/issues/1083