### PR TITLE
Make array creation thread local

### DIFF
--- a/src/test/java/datawave/query/composite/CompositeMetadataTest.java
+++ b/src/test/java/datawave/query/composite/CompositeMetadataTest.java
@@ -9,6 +9,10 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.stream.IntStream;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 public class CompositeMetadataTest {
     
@@ -77,6 +81,18 @@ public class CompositeMetadataTest {
             Assert.assertEquals(compositeMetadata.compositeTransitionDatesByType.get(ingestType),
                             destCompMetadata.compositeTransitionDatesByType.get(ingestType));
         }
+    }
+    
+    @Test
+    public void serializeManyThreads() {
+        final ExecutorService executor = Executors.newFixedThreadPool(5);
+        for (int i = 0; i < 100; i++) {
+            executor.submit(() -> {
+                byte[] compMetadataBytes = CompositeMetadata.toBytes(compositeMetadata);
+                Assert.assertNotNull(compMetadataBytes);
+            });
+        }
+        executor.shutdown();
     }
     
 }


### PR DESCRIPTION
An IllegalArgument exception will occur in the DefaultQueryPlanner as a result of using a shared static linked buffer. This change makes that buffer thread local. The test exploits the issue at its core. 