### PR TITLE
Updating additional methods for empty datatype filters

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
         <relativePath />
     </parent>
     <artifactId>metadata-utils</artifactId>
-    <version>1.13</version>
+    <version>2.1.1-SNAPSHOT</version>
     <url>https://code.nsa.gov/datawave-metadata-utils</url>
     <licenses>
         <license>

--- a/src/main/java/datawave/query/util/MetadataHelper.java
+++ b/src/main/java/datawave/query/util/MetadataHelper.java
@@ -322,14 +322,7 @@ public class MetadataHelper {
         if (log.isTraceEnabled())
             log.trace("loadAllFields() with auths:" + this.allFieldMetadataHelper.getAuths() + " returned " + allFields);
         
-        Set<String> fields = new HashSet<>();
-        if (ingestTypeFilter == null || ingestTypeFilter.isEmpty()) {
-            fields.addAll(allFields.values());
-        } else {
-            for (String datatype : ingestTypeFilter) {
-                fields.addAll(allFields.get(datatype));
-            }
-        }
+        Set<String> fields = getFields(allFields, ingestTypeFilter);
         
         // Add any additional fields that are created at evaluation time and are hence not in the metadata table.
         fields.addAll(evaluationOnlyFields);
@@ -395,15 +388,7 @@ public class MetadataHelper {
         
         Multimap<String,String> indexOnlyFields = this.allFieldMetadataHelper.getIndexOnlyFields();
         
-        Set<String> fields = new HashSet<>();
-        if (ingestTypeFilter == null || ingestTypeFilter.isEmpty()) {
-            fields.addAll(indexOnlyFields.values());
-        } else {
-            for (String datatype : ingestTypeFilter) {
-                fields.addAll(indexOnlyFields.get(datatype));
-            }
-        }
-        return Collections.unmodifiableSet(fields);
+        return getFields(indexOnlyFields, ingestTypeFilter);
     }
     
     public QueryModel getQueryModel(String modelTableName, String modelName) throws TableNotFoundException, ExecutionException {

--- a/src/main/java/datawave/query/util/MetadataHelper.java
+++ b/src/main/java/datawave/query/util/MetadataHelper.java
@@ -325,9 +325,7 @@ public class MetadataHelper {
         fields.addAll(getFields(allFields, ingestTypeFilter));
         
         // Add any additional fields that are created at evaluation time and are hence not in the metadata table.
-        if (!evaluationOnlyFields.isEmpty()) {
-            fields.addAll(evaluationOnlyFields);
-        }
+        fields.addAll(evaluationOnlyFields);
         
         if (log.isTraceEnabled())
             log.trace("getAllFields(" + ingestTypeFilter + ") returning " + fields);

--- a/src/main/java/datawave/query/util/MetadataHelper.java
+++ b/src/main/java/datawave/query/util/MetadataHelper.java
@@ -97,13 +97,13 @@ import java.util.stream.StreamSupport;
 @Scope("prototype")
 public class MetadataHelper {
     private static final Logger log = LoggerFactory.getLogger(MetadataHelper.class);
-
+    
     public static final String NULL_BYTE = "\0";
-
+    
     protected static final Text PV = new Text("pv");
-
-    protected static final Function<MetadataEntry, String> toFieldName = new MetadataEntryToFieldName(), toDatatype = new MetadataEntryToDatatype();
-
+    
+    protected static final Function<MetadataEntry,String> toFieldName = new MetadataEntryToFieldName(), toDatatype = new MetadataEntryToDatatype();
+    
     protected String getDatatype(Key k) {
         String datatype = k.getColumnQualifier().toString();
         int index = datatype.indexOf('\0');
@@ -112,52 +112,52 @@ public class MetadataHelper {
         }
         return datatype;
     }
-
+    
     protected final Metadata metadata = new Metadata();
-
+    
     protected final List<Text> metadataIndexColfs = Arrays.asList(ColumnFamilyConstants.COLF_I, ColumnFamilyConstants.COLF_RI);
     protected final List<Text> metadataNormalizedColfs = Arrays.asList(ColumnFamilyConstants.COLF_N);
     protected final List<Text> metadataTypeColfs = Arrays.asList(ColumnFamilyConstants.COLF_T);
     protected final List<Text> metadataCompositeIndexColfs = Arrays.asList(ColumnFamilyConstants.COLF_CI);
     protected final List<Text> metadataCardinalityColfs = Arrays.asList(ColumnFamilyConstants.COLF_COUNT);
-
+    
     protected final Connector connector;
     protected final Instance instance;
     protected final String metadataTableName;
     protected final Set<Authorizations> auths;
     protected Set<Authorizations> fullUserAuths;
-
+    
     protected final AllFieldMetadataHelper allFieldMetadataHelper;
     protected final Collection<Authorizations> allMetadataAuths;
-
+    
     // a set of fields that are dynamically created at evaluation time, and are not registered in the metadata table
     protected Set<String> evaluationOnlyFields = Collections.emptySet();
-
+    
     public MetadataHelper(AllFieldMetadataHelper allFieldMetadataHelper, Collection<Authorizations> allMetadataAuths, Connector connector,
-                          String metadataTableName, Set<Authorizations> auths, Set<Authorizations> fullUserAuths) {
+                    String metadataTableName, Set<Authorizations> auths, Set<Authorizations> fullUserAuths) {
         Preconditions.checkNotNull(allFieldMetadataHelper, "An AllFieldMetadataHelper is required by MetadataHelper");
         this.allFieldMetadataHelper = allFieldMetadataHelper;
-
+        
         Preconditions.checkNotNull(allMetadataAuths, "The set of all metadata authorization is required by MetadataHelper");
         this.allMetadataAuths = allMetadataAuths;
-
+        
         Preconditions.checkNotNull(connector, "A valid Accumulo Connector is required by MetadataHelper");
         this.connector = connector;
         this.instance = connector.getInstance();
-
+        
         Preconditions.checkNotNull(metadataTableName, "The name of the metadata table is required by MetadataHelper");
         this.metadataTableName = metadataTableName;
-
+        
         Preconditions.checkNotNull(auths, "Authorizations are required by MetadataHelper");
         this.auths = auths;
-
+        
         Preconditions.checkNotNull(fullUserAuths, "The full set of user authorizations is required by MetadataHelper");
         this.fullUserAuths = fullUserAuths;
         log.debug("initialized with auths subset: {}", this.auths);
-
+        
         log.trace("Constructor connector: {} with auths: {} and metadata table name: {}", connector.getClass().getCanonicalName(), auths, metadataTableName);
     }
-
+    
     /**
      * allMetadataAuths is a singleton Collection of one Authorizations instance that contains all of the auths required to see everything in the Metadata
      * table. userAuths is a Collection of Authorizations, every one of which must contain th
@@ -167,7 +167,7 @@ public class MetadataHelper {
      * @return
      */
     public static boolean userHasAllMetadataAuths(Collection<Authorizations> usersAuthsCollection, Collection<Authorizations> allMetadataAuthsCollection) {
-
+        
         // first, minimize the usersAuths:
         Collection<Authorizations> minimizedCollection = AuthorizationsMinimizer.minimize(usersAuthsCollection);
         // now, the first entry in the minimized auths should have everything common to every Authorizations in the set
@@ -175,9 +175,9 @@ public class MetadataHelper {
         Authorizations allMetadataAuths = allMetadataAuthsCollection.iterator().next(); // get the first (and only) one
         Authorizations minimized = minimizedCollection.iterator().next(); // get the first one, which has all auths common to all in the original collection
         return StreamSupport.stream(minimized.spliterator(), false).map(String::new).collect(Collectors.toSet())
-                .containsAll(StreamSupport.stream(allMetadataAuths.spliterator(), false).map(String::new).collect(Collectors.toSet()));
+                        .containsAll(StreamSupport.stream(allMetadataAuths.spliterator(), false).map(String::new).collect(Collectors.toSet()));
     }
-
+    
     /**
      * allMetadataAuthsCollection is a singleton Collection of one Authorizations instance that contains all of the auths required to see everything in the
      * Metadata table. userAuthsCollection contains the user's auths. This method will return the retention of the user's auths from the
@@ -188,7 +188,7 @@ public class MetadataHelper {
      * @return
      */
     public static Collection<String> getUsersMetadataAuthorizationSubset(Collection<Authorizations> usersAuthsCollection,
-                                                                         Collection<Authorizations> allMetadataAuthsCollection) {
+                    Collection<Authorizations> allMetadataAuthsCollection) {
         if (log.isTraceEnabled()) {
             log.trace("allMetadataAuthsCollection:" + allMetadataAuthsCollection);
             log.trace("usersAuthsCollection:" + usersAuthsCollection);
@@ -198,7 +198,7 @@ public class MetadataHelper {
         if (log.isTraceEnabled()) {
             log.trace("minimizedCollection:" + minimizedCollection);
         }
-
+        
         // now, the first entry in the minimized auths should have everything common to every Authorizations in the set
         // make sure that the first entry contains all the Authorizations in the allMetadataAuths
         Authorizations allMetadataAuths = allMetadataAuthsCollection.iterator().next(); // get the first (and only) one
@@ -207,7 +207,7 @@ public class MetadataHelper {
             log.trace("first of users auths minimized:" + minimized);
         }
         Set<String> minimizedUserAuths = StreamSupport.stream(minimized.spliterator(), false).map(String::new).collect(Collectors.toSet());
-
+        
         Collection<String> minimizedAllMetadataAuths = StreamSupport.stream(allMetadataAuths.spliterator(), false).map(String::new).collect(Collectors.toSet());
         minimizedAllMetadataAuths.retainAll(minimizedUserAuths);
         if (log.isTraceEnabled()) {
@@ -215,9 +215,9 @@ public class MetadataHelper {
         }
         return minimizedAllMetadataAuths;
     }
-
+    
     private Set<Set<String>> getAllMetadataAuthsPowerSet(Collection<Authorizations> allMetadataAuthsCollection) {
-
+        
         // first, minimize the usersAuths:
         Collection<Authorizations> minimizedCollection = AuthorizationsMinimizer.minimize(allMetadataAuthsCollection);
         // now, the first entry in the minimized auths should have everything common to every Authorizations in the set
@@ -235,21 +235,21 @@ public class MetadataHelper {
         }
         return set;
     }
-
-    public Map<Set<String>, TypeMetadata> getTypeMetadataMap() throws TableNotFoundException {
+    
+    public Map<Set<String>,TypeMetadata> getTypeMetadataMap() throws TableNotFoundException {
         Collection<Set<String>> powerset = getAllMetadataAuthsPowerSet(this.allMetadataAuths);
         if (log.isTraceEnabled()) {
             log.trace("powerset:" + powerset);
         }
-        Map<Set<String>, TypeMetadata> map = Maps.newHashMap();
-
+        Map<Set<String>,TypeMetadata> map = Maps.newHashMap();
+        
         for (Set<String> a : powerset) {
             if (log.isTraceEnabled()) {
                 log.trace("get TypeMetadata with auths:" + a);
             }
-
+            
             Authorizations at = new Authorizations(a.toArray(new String[a.size()]));
-
+            
             if (log.isTraceEnabled()) {
                 log.trace("made an Authorizations:" + at);
             }
@@ -258,7 +258,7 @@ public class MetadataHelper {
         }
         return map;
     }
-
+    
     public String getUsersMetadataAuthorizationSubset() {
         StringBuilder buf = new StringBuilder();
         if (this.auths != null && this.allMetadataAuths != null) {
@@ -271,23 +271,23 @@ public class MetadataHelper {
         }
         return buf.toString();
     }
-
+    
     public Collection<Authorizations> getAllMetadataAuths() {
         return allMetadataAuths;
     }
-
+    
     public Set<Authorizations> getAuths() {
         return auths;
     }
-
+    
     public Set<Authorizations> getFullUserAuths() {
         return fullUserAuths;
     }
-
+    
     public AllFieldMetadataHelper getAllFieldMetadataHelper() {
         return this.allFieldMetadataHelper;
     }
-
+    
     /**
      * Get the metadata fully populated
      *
@@ -298,7 +298,7 @@ public class MetadataHelper {
     public Metadata getMetadata() throws TableNotFoundException, ExecutionException, MarkingFunctions.Exception {
         return getMetadata(null);
     }
-
+    
     /**
      * Get the metadata fully populated
      *
@@ -309,7 +309,7 @@ public class MetadataHelper {
     public Metadata getMetadata(Set<String> ingestTypeFilter) throws TableNotFoundException, ExecutionException, MarkingFunctions.Exception {
         return new Metadata(this, ingestTypeFilter);
     }
-
+    
     /**
      * Fetch the {@link Set} of all fields contained in the database. This will provide a cached view of the fields which is updated every
      * {@code updateInterval} milliseconds.
@@ -318,30 +318,31 @@ public class MetadataHelper {
      * @throws TableNotFoundException
      */
     public Set<String> getAllFields(Set<String> ingestTypeFilter) throws TableNotFoundException {
-        Multimap<String, String> allFields = this.allFieldMetadataHelper.loadAllFields();
+        Multimap<String,String> allFields = this.allFieldMetadataHelper.loadAllFields();
         if (log.isTraceEnabled())
             log.trace("loadAllFields() with auths:" + this.allFieldMetadataHelper.getAuths() + " returned " + allFields);
-
-        Set<String> fields = getFields(allFields, ingestTypeFilter);
-
+        
+        Set<String> fields = new HashSet<>();
+        fields.addAll(getFields(allFields, ingestTypeFilter));
+        
         // Add any additional fields that are created at evaluation time and are hence not in the metadata table.
         if (!evaluationOnlyFields.isEmpty()) {
             fields.addAll(evaluationOnlyFields);
         }
-
+        
         if (log.isTraceEnabled())
             log.trace("getAllFields(" + ingestTypeFilter + ") returning " + fields);
         return Collections.unmodifiableSet(fields);
     }
-
+    
     public Set<String> getEvaluationOnlyFields() {
         return Collections.unmodifiableSet(evaluationOnlyFields);
     }
-
+    
     public void setEvaluationOnlyFields(Set<String> evaluationOnlyFields) {
         this.evaluationOnlyFields = (evaluationOnlyFields == null ? Collections.emptySet() : new HashSet<>(evaluationOnlyFields));
     }
-
+    
     /**
      * Get the fields that have values not in the same form as the event (excluding normalization). This would include index only fields, term frequency fields
      * (as the index may contain tokens), and composite fields.
@@ -350,11 +351,11 @@ public class MetadataHelper {
      * @return the non-event fields
      */
     public Set<String> getNonEventFields(Set<String> ingestTypeFilter) throws TableNotFoundException {
-
+        
         Set<String> fields = new HashSet<>();
         fields.addAll(getIndexOnlyFields(ingestTypeFilter));
         fields.addAll(getTermFrequencyFields(ingestTypeFilter));
-        Multimap<String, String> compToFieldMap = getCompositeToFieldMap(ingestTypeFilter);
+        Multimap<String,String> compToFieldMap = getCompositeToFieldMap(ingestTypeFilter);
         for (String compField : compToFieldMap.keySet()) {
             if (!isOverloadedCompositeField(compToFieldMap, compField)) {
                 // a composite is only a non-event field if it is composed from 1 or more non-event fields
@@ -366,20 +367,20 @@ public class MetadataHelper {
                 }
             }
         }
-
+        
         return Collections.unmodifiableSet(fields);
     }
-
-    static boolean isOverloadedCompositeField(Multimap<String, String> compositeFieldDefinitions, String compositeFieldName) {
+    
+    static boolean isOverloadedCompositeField(Multimap<String,String> compositeFieldDefinitions, String compositeFieldName) {
         return isOverloadedCompositeField(compositeFieldDefinitions.get(compositeFieldName), compositeFieldName);
     }
-
+    
     static boolean isOverloadedCompositeField(Collection<String> compFields, String compositeFieldName) {
         if (compFields != null && !compFields.isEmpty())
             return compFields.stream().findFirst().get().equals(compositeFieldName);
         return false;
     }
-
+    
     /**
      * Fetch the {@link Set} of index-only fields.
      *
@@ -387,51 +388,51 @@ public class MetadataHelper {
      * @throws TableNotFoundException
      */
     public Set<String> getIndexOnlyFields(Set<String> ingestTypeFilter) throws TableNotFoundException {
-
-        Multimap<String, String> indexOnlyFields = this.allFieldMetadataHelper.getIndexOnlyFields();
-
+        
+        Multimap<String,String> indexOnlyFields = this.allFieldMetadataHelper.getIndexOnlyFields();
+        
         return getFields(indexOnlyFields, ingestTypeFilter);
     }
-
+    
     public QueryModel getQueryModel(String modelTableName, String modelName) throws TableNotFoundException, ExecutionException {
         return getQueryModel(modelTableName, modelName, this.getIndexOnlyFields(null));
     }
-
+    
     public QueryModel getQueryModel(String modelTableName, String modelName, Collection<String> unevaluatedFields) throws TableNotFoundException {
         return getQueryModel(modelTableName, modelName, unevaluatedFields, null);
     }
-
+    
     /***
      * @param modelName
      * @return
      * @throws TableNotFoundException
      */
     public QueryModel getQueryModel(String modelTableName, String modelName, Collection<String> unevaluatedFields, Set<String> ingestTypeFilter)
-            throws TableNotFoundException {
+                    throws TableNotFoundException {
         // Note that we used to cache this, however this method is dependent on some variables in the all fields metadata helper
         // @Cacheable(value = "getQueryModel", key = "{#root.target.auths,#p0,#p1,#p2,#p3}", cacheManager = "metadataHelperCacheManager")
-
+        
         Preconditions.checkNotNull(modelTableName);
         Preconditions.checkNotNull(modelName);
-
+        
         if (log.isTraceEnabled())
             log.trace("getQueryModel(" + modelTableName + "," + modelName + "," + unevaluatedFields + "," + ingestTypeFilter + ")");
         QueryModel queryModel = new QueryModel();
-
+        
         TraceStopwatch stopWatch = new TraceStopwatch("MetadataHelper -- Building Query Model from instance");
         stopWatch.start();
-
+        
         if (log.isTraceEnabled())
             log.trace("using connector: " + connector.getClass().getCanonicalName() + " with auths: " + auths + " and model table name: " + modelTableName
-                    + " looking at model " + modelName + " unevaluatedFields " + unevaluatedFields);
-
+                            + " looking at model " + modelName + " unevaluatedFields " + unevaluatedFields);
+        
         Scanner scan = ScannerHelper.createScanner(connector, modelTableName, auths);
         scan.setRange(new Range());
         scan.fetchColumnFamily(new Text(modelName));
         // We need the entire Model so we can do both directions.
         final Set<String> allFields = this.getAllFields(ingestTypeFilter);
-
-        for (Map.Entry<Key, Value> entry : scan) {
+        
+        for (Map.Entry<Key,Value> entry : scan) {
             try {
                 FieldMapping mapping = ModelKeyParser.parseKey(entry.getKey());
                 if (mapping.isLenient()) {
@@ -443,7 +444,7 @@ public class MetadataHelper {
                         queryModel.addTermToModel(mapping.getModelFieldName(), mapping.getFieldName());
                     } else if (log.isTraceEnabled()) {
                         log.trace("Ignoring forward mapping of " + mapping.getFieldName() + " for " + mapping.getModelFieldName()
-                                + " because the metadata table has no reference to it");
+                                        + " because the metadata table has no reference to it");
                     }
                 } else {
                     queryModel.addTermToReverseModel(mapping.getFieldName(), mapping.getModelFieldName());
@@ -452,7 +453,7 @@ public class MetadataHelper {
                 log.warn("Ignoring unparseable key " + entry.getKey());
             }
         }
-
+        
         if (queryModel.getReverseQueryMapping().isEmpty()) {
             if (log.isTraceEnabled()) {
                 log.trace("empty query model for " + this);
@@ -461,12 +462,12 @@ public class MetadataHelper {
                 log.error("Query Model should not be empty...");
             }
         }
-
+        
         stopWatch.stop();
-
+        
         return queryModel;
     }
-
+    
     /***
      * @param modelTableName
      * @return a list of query model names
@@ -475,16 +476,16 @@ public class MetadataHelper {
     @Cacheable(value = "getQueryModelNames", key = "{#root.target.auths,#table}", cacheManager = "metadataHelperCacheManager")
     public Set<String> getQueryModelNames(String modelTableName) throws TableNotFoundException {
         Preconditions.checkNotNull(modelTableName);
-
+        
         if (log.isTraceEnabled())
             log.trace("getQueryModelNames(" + modelTableName + ")");
-
+        
         TraceStopwatch stopWatch = new TraceStopwatch("MetadataHelper -- Getting query model names");
         stopWatch.start();
-
+        
         if (log.isTraceEnabled())
             log.trace("using connector: " + connector.getClass().getCanonicalName() + " with auths: " + auths + " and model table name: " + modelTableName);
-
+        
         Scanner scan = ScannerHelper.createScanner(connector, modelTableName, auths);
         scan.setRange(new Range());
         Set<String> modelNames = new HashSet<>();
@@ -503,8 +504,8 @@ public class MetadataHelper {
         ignoreColfs.add(ColumnFamilyConstants.COLF_TF);
         ignoreColfs.add(ColumnFamilyConstants.COLF_VERSION);
         ignoreColfs.add(ColumnFamilyConstants.COLF_EXP);
-
-        for (Map.Entry<Key, Value> entry : scan) {
+        
+        for (Map.Entry<Key,Value> entry : scan) {
             Text cf = entry.getKey().getColumnFamily();
             if (!ignoreColfs.contains(entry.getKey().getColumnFamily())) {
                 if (entry.getKey().getColumnQualifier().toString().endsWith("\0forward")) {
@@ -512,12 +513,12 @@ public class MetadataHelper {
                 }
             }
         }
-
+        
         stopWatch.stop();
-
+        
         return modelNames;
     }
-
+    
     /**
      * Determines whether a field has been reverse indexed by looking for the ri column in the metadata table
      *
@@ -528,16 +529,16 @@ public class MetadataHelper {
      */
     public boolean isReverseIndexed(String fieldName, Set<String> ingestTypeFilter) throws TableNotFoundException {
         Preconditions.checkNotNull(fieldName);
-
-        Entry<String, Entry<String, Set<String>>> entry = Maps.immutableEntry(metadataTableName, Maps.immutableEntry(fieldName, ingestTypeFilter));
-
+        
+        Entry<String,Entry<String,Set<String>>> entry = Maps.immutableEntry(metadataTableName, Maps.immutableEntry(fieldName, ingestTypeFilter));
+        
         try {
             return this.allFieldMetadataHelper.isIndexed(ColumnFamilyConstants.COLF_RI, entry);
         } catch (InstantiationException | ExecutionException e) {
             throw new RuntimeException(e);
         }
     }
-
+    
     /**
      * Determines whether a field has been indexed by looking for the i column in the metadata table
      *
@@ -548,17 +549,17 @@ public class MetadataHelper {
      */
     public boolean isIndexed(String fieldName, Set<String> ingestTypeFilter) throws TableNotFoundException {
         Preconditions.checkNotNull(fieldName);
-
-        Entry<String, Entry<String, Set<String>>> entry = Maps.immutableEntry(metadataTableName, Maps.immutableEntry(fieldName, ingestTypeFilter));
-
+        
+        Entry<String,Entry<String,Set<String>>> entry = Maps.immutableEntry(metadataTableName, Maps.immutableEntry(fieldName, ingestTypeFilter));
+        
         try {
             return this.allFieldMetadataHelper.isIndexed(ColumnFamilyConstants.COLF_I, entry);
         } catch (InstantiationException | ExecutionException e) {
             throw new RuntimeException(e);
         }
-
+        
     }
-
+    
     /**
      * Determines whether a field has been tokenized by looking for the tf column in the metadata table
      *
@@ -569,16 +570,16 @@ public class MetadataHelper {
      */
     public boolean isTokenized(String fieldName, Set<String> ingestTypeFilter) throws TableNotFoundException {
         Preconditions.checkNotNull(fieldName);
-
-        Entry<String, Entry<String, Set<String>>> entry = Maps.immutableEntry(metadataTableName, Maps.immutableEntry(fieldName, ingestTypeFilter));
-
+        
+        Entry<String,Entry<String,Set<String>>> entry = Maps.immutableEntry(metadataTableName, Maps.immutableEntry(fieldName, ingestTypeFilter));
+        
         try {
             return this.allFieldMetadataHelper.isIndexed(ColumnFamilyConstants.COLF_TF, entry);
         } catch (InstantiationException | ExecutionException e) {
             throw new RuntimeException(e);
         }
     }
-
+    
     /**
      * Returns a Set of all TextNormalizers in use by any type in Accumulo
      *
@@ -588,20 +589,20 @@ public class MetadataHelper {
      * @throws TableNotFoundException
      */
     @Cacheable(value = "getFacets", key = "{#root.target.auths,#table}", cacheManager = "metadataHelperCacheManager")
-    public Multimap<String, String> getFacets(String table) throws InstantiationException, IllegalAccessException, TableNotFoundException {
+    public Multimap<String,String> getFacets(String table) throws InstantiationException, IllegalAccessException, TableNotFoundException {
         log.debug("cache fault for getFacets(" + this.auths + "," + table + ")");
-        Multimap<String, String> fieldPivots = HashMultimap.create();
-
+        Multimap<String,String> fieldPivots = HashMultimap.create();
+        
         Scanner bs = ScannerHelper.createScanner(connector, table, auths);
         Range range = new Range();
-
+        
         bs.setRange(range);
-
+        
         bs.fetchColumnFamily(PV);
-
-        for (Entry<Key, Value> entry : bs) {
+        
+        for (Entry<Key,Value> entry : bs) {
             Key key = entry.getKey();
-
+            
             if (null != key.getRow()) {
                 String[] parts = StringUtils.split(key.getRow().toString(), "\0");
                 if (parts.length == 2) {
@@ -613,10 +614,10 @@ public class MetadataHelper {
                 log.warn("Row null in ColumnFamilyConstants for key: " + key);
             }
         }
-
+        
         return fieldPivots;
     }
-
+    
     /**
      * Returns a Set of all counts / cardinalities
      *
@@ -626,30 +627,30 @@ public class MetadataHelper {
      * @throws TableNotFoundException
      */
     @Cacheable(value = "getTermCounts", key = "{#root.target.auths,#root.target.metadataTableName}", cacheManager = "metadataHelperCacheManager")
-    public Map<String, Map<String, MetadataCardinalityCounts>> getTermCounts() throws InstantiationException, IllegalAccessException, TableNotFoundException {
+    public Map<String,Map<String,MetadataCardinalityCounts>> getTermCounts() throws InstantiationException, IllegalAccessException, TableNotFoundException {
         log.debug("cache fault for getTermCounts(" + this.auths + "," + this.metadataTableName + ")");
-        Map<String, Map<String, MetadataCardinalityCounts>> allCounts = Maps.newHashMap();
-
+        Map<String,Map<String,MetadataCardinalityCounts>> allCounts = Maps.newHashMap();
+        
         if (log.isTraceEnabled())
             log.trace("getTermCounts from table: " + metadataTableName);
-
+        
         Scanner bs = ScannerHelper.createScanner(connector, metadataTableName, auths);
         Range range = new Range();
-
+        
         bs.setRange(range);
-
+        
         // Fetch all of the index columns
         for (Text colf : metadataCardinalityColfs) {
             bs.fetchColumnFamily(colf);
         }
-
+        
         try {
-            for (Entry<Key, Value> entry : bs) {
+            for (Entry<Key,Value> entry : bs) {
                 Key key = entry.getKey();
-
+                
                 if (null != key.getRow()) {
                     MetadataCardinalityCounts counts = new MetadataCardinalityCounts(key, entry.getValue());
-                    Map<String, MetadataCardinalityCounts> values = allCounts.get(counts.getField());
+                    Map<String,MetadataCardinalityCounts> values = allCounts.get(counts.getField());
                     if (values == null) {
                         values = Maps.newHashMapWithExpectedSize(5);
                         allCounts.put(counts.getField(), values);
@@ -662,10 +663,10 @@ public class MetadataHelper {
         } finally {
             bs.close();
         }
-
+        
         return Collections.unmodifiableMap(allCounts);
     }
-
+    
     /**
      * Returns a Set of all Counts using the connector's principal's auths. This resulting informations cannot be exposed outside of the system.
      *
@@ -675,33 +676,33 @@ public class MetadataHelper {
      * @throws TableNotFoundException
      */
     @Cacheable(value = "getTermCountsWithRootAuths", key = "{#root.target.metadataTableName}", cacheManager = "metadataHelperCacheManager")
-    public Map<String, Map<String, MetadataCardinalityCounts>> getTermCountsWithRootAuths()
-            throws InstantiationException, IllegalAccessException, TableNotFoundException, AccumuloSecurityException, AccumuloException {
+    public Map<String,Map<String,MetadataCardinalityCounts>> getTermCountsWithRootAuths()
+                    throws InstantiationException, IllegalAccessException, TableNotFoundException, AccumuloSecurityException, AccumuloException {
         log.debug("cache fault for getTermCounts(" + this.auths + "," + this.metadataTableName + ")");
-        Map<String, Map<String, MetadataCardinalityCounts>> allCounts = Maps.newHashMap();
-
+        Map<String,Map<String,MetadataCardinalityCounts>> allCounts = Maps.newHashMap();
+        
         if (log.isTraceEnabled())
             log.trace("getTermCounts from table: " + metadataTableName);
-
+        
         Authorizations rootAuths = connector.securityOperations().getUserAuthorizations(connector.whoami());
-
+        
         Scanner bs = ScannerHelper.createScanner(connector, metadataTableName, Collections.singleton(rootAuths));
         Range range = new Range();
-
+        
         bs.setRange(range);
-
+        
         // Fetch all of the index columns
         for (Text colf : metadataCardinalityColfs) {
             bs.fetchColumnFamily(colf);
         }
-
+        
         try {
-            for (Entry<Key, Value> entry : bs) {
+            for (Entry<Key,Value> entry : bs) {
                 Key key = entry.getKey();
-
+                
                 if (null != key.getRow()) {
                     MetadataCardinalityCounts counts = new MetadataCardinalityCounts(key, entry.getValue());
-                    Map<String, MetadataCardinalityCounts> values = allCounts.get(counts.getField());
+                    Map<String,MetadataCardinalityCounts> values = allCounts.get(counts.getField());
                     if (values == null) {
                         values = Maps.newHashMapWithExpectedSize(5);
                         allCounts.put(counts.getField(), values);
@@ -714,10 +715,10 @@ public class MetadataHelper {
         } finally {
             bs.close();
         }
-
+        
         return Collections.unmodifiableMap(allCounts);
     }
-
+    
     /**
      * Returns a Set of all TextNormalizers in use by any type in Accumulo
      *
@@ -732,21 +733,21 @@ public class MetadataHelper {
         Set<String> normalizedFields = Sets.newHashSetWithExpectedSize(10);
         if (log.isTraceEnabled())
             log.trace("getAllNormalized from table: " + metadataTableName);
-
+        
         Scanner bs = ScannerHelper.createScanner(connector, metadataTableName, auths);
         Range range = new Range();
-
+        
         bs.setRange(range);
-
+        
         // Fetch all of the index columns
         for (Text colf : metadataNormalizedColfs) {
             bs.fetchColumnFamily(colf);
         }
-
+        
         try {
-            for (Entry<Key, Value> entry : bs) {
+            for (Entry<Key,Value> entry : bs) {
                 Key key = entry.getKey();
-
+                
                 if (null != key.getRow()) {
                     normalizedFields.add(key.getRow().toString());
                 } else {
@@ -756,10 +757,10 @@ public class MetadataHelper {
         } finally {
             bs.close();
         }
-
+        
         return Collections.unmodifiableSet(normalizedFields);
     }
-
+    
     /**
      * Returns a Set of all Types in use by any type in Accumulo
      *
@@ -771,7 +772,7 @@ public class MetadataHelper {
     public Set<Type<?>> getAllDatatypes() throws InstantiationException, IllegalAccessException, TableNotFoundException {
         return this.allFieldMetadataHelper.getAllDatatypes();
     }
-
+    
     /**
      * A map of composite name to the ordered list of it for example, mapping of {@code COLOR -> ['COLOR_WHEELS,0', 'MAKE_COLOR,1' ]}. If called multiple time,
      * it returns the same cached map.
@@ -779,62 +780,63 @@ public class MetadataHelper {
      * @return An unmodifiable Multimap
      * @throws TableNotFoundException
      */
-    public Multimap<String, String> getCompositeToFieldMap() throws TableNotFoundException {
+    public Multimap<String,String> getCompositeToFieldMap() throws TableNotFoundException {
         return this.allFieldMetadataHelper.getCompositeToFieldMap();
     }
-
-    public Multimap<String, String> getCompositeToFieldMap(Set<String> ingestTypeFilter) throws TableNotFoundException {
-
+    
+    public Multimap<String,String> getCompositeToFieldMap(Set<String> ingestTypeFilter) throws TableNotFoundException {
+        
         return this.allFieldMetadataHelper.getCompositeToFieldMap(ingestTypeFilter);
     }
-
+    
     /**
      * A map of composite name to transition date.
      *
      * @return An unmodifiable Map
      * @throws TableNotFoundException
      */
-    public Map<String, Date> getCompositeTransitionDateMap() throws TableNotFoundException {
+    public Map<String,Date> getCompositeTransitionDateMap() throws TableNotFoundException {
         return this.allFieldMetadataHelper.getCompositeTransitionDateMap();
     }
-
-    public Map<String, Date> getCompositeTransitionDateMap(Set<String> ingestTypeFilter) throws TableNotFoundException {
+    
+    public Map<String,Date> getCompositeTransitionDateMap(Set<String> ingestTypeFilter) throws TableNotFoundException {
         return this.allFieldMetadataHelper.getCompositeTransitionDateMap(ingestTypeFilter);
     }
-
+    
     /**
      * A map of whindex field to creation date.
      *
      * @return An unmodifiable Map
      * @throws TableNotFoundException
      */
-    public Map<String, Date> getWhindexCreationDateMap() throws TableNotFoundException {
+    public Map<String,Date> getWhindexCreationDateMap() throws TableNotFoundException {
         return this.allFieldMetadataHelper.getWhindexCreationDateMap();
     }
-
-    public Map<String, Date> getWhindexCreationDateMap(Set<String> ingestTypeFilter) throws TableNotFoundException {
+    
+    public Map<String,Date> getWhindexCreationDateMap(Set<String> ingestTypeFilter) throws TableNotFoundException {
         return this.allFieldMetadataHelper.getWhindexCreationDateMap(ingestTypeFilter);
     }
-
+    
     /**
      * A map of composite name to field separator.
      *
      * @return An unmodifiable Map
      * @throws TableNotFoundException
      */
-    public Map<String, String> getCompositeFieldSeparatorMap() throws TableNotFoundException {
+    public Map<String,String> getCompositeFieldSeparatorMap() throws TableNotFoundException {
         return this.allFieldMetadataHelper.getCompositeFieldSeparatorMap();
     }
-
-    public Map<String, String> getCompositeFieldSeparatorMap(Set<String> ingestTypeFilter) throws TableNotFoundException {
+    
+    public Map<String,String> getCompositeFieldSeparatorMap(Set<String> ingestTypeFilter) throws TableNotFoundException {
         return this.allFieldMetadataHelper.getCompositeFieldSeparatorMap(ingestTypeFilter);
     }
-
+    
     /**
      * Fetch the set of {@link Type}s that are configured for this <code>fieldName</code> as specified in the table pointed to by the
      * <code>metadataTableName</code> parameter.
      *
-     * @param fieldName The name of the field to fetch the {@link Type}s for. If null then all dataTypes are returned.
+     * @param fieldName
+     *            The name of the field to fetch the {@link Type}s for. If null then all dataTypes are returned.
      * @return
      * @throws InstantiationException
      * @throws IllegalAccessException
@@ -843,7 +845,7 @@ public class MetadataHelper {
     public Set<Type<?>> getDatatypesForField(String fieldName) throws InstantiationException, IllegalAccessException, TableNotFoundException {
         return getDatatypesForField(fieldName, null);
     }
-
+    
     /**
      * @return
      * @throws InstantiationException
@@ -851,10 +853,10 @@ public class MetadataHelper {
      * @throws TableNotFoundException
      */
     public Set<Type<?>> getDatatypesForField(String fieldName, Set<String> ingestTypeFilter)
-            throws InstantiationException, IllegalAccessException, TableNotFoundException {
-
+                    throws InstantiationException, IllegalAccessException, TableNotFoundException {
+        
         Set<Type<?>> dataTypes = new HashSet<>();
-        Multimap<String, Type<?>> mm = this.allFieldMetadataHelper.getFieldsToDatatypes(ingestTypeFilter);
+        Multimap<String,Type<?>> mm = this.allFieldMetadataHelper.getFieldsToDatatypes(ingestTypeFilter);
         if (fieldName == null) {
             dataTypes.addAll(mm.values());
         } else {
@@ -865,23 +867,23 @@ public class MetadataHelper {
         }
         return dataTypes;
     }
-
+    
     public TypeMetadata getTypeMetadata() throws TableNotFoundException {
         return this.allFieldMetadataHelper.getTypeMetadata(null);
     }
-
+    
     public TypeMetadata getTypeMetadata(Set<String> ingestTypeFilter) throws TableNotFoundException {
         return this.allFieldMetadataHelper.getTypeMetadata(ingestTypeFilter);
     }
-
+    
     public CompositeMetadata getCompositeMetadata() throws TableNotFoundException {
         return this.allFieldMetadataHelper.getCompositeMetadata(null);
     }
-
+    
     public CompositeMetadata getCompositeMetadata(Set<String> ingestTypeFilter) throws TableNotFoundException {
         return this.allFieldMetadataHelper.getCompositeMetadata(ingestTypeFilter);
     }
-
+    
     /**
      * Fetch the Set of all fields marked as containing term frequency information, {@link ColumnFamilyConstants#COLF_TF}.
      *
@@ -890,18 +892,18 @@ public class MetadataHelper {
      * @throws ExecutionException
      */
     @Cacheable(value = "getEdges", key = "{#root.target.fullUserAuths,#root.target.metadataTableName}")
-    public SetMultimap<Key, Value> getEdges() throws TableNotFoundException, ExecutionException {
+    public SetMultimap<Key,Value> getEdges() throws TableNotFoundException, ExecutionException {
         log.debug("cache fault for getEdges(" + this.auths + ")");
-        SetMultimap<Key, Value> edges = HashMultimap.create();
+        SetMultimap<Key,Value> edges = HashMultimap.create();
         if (log.isTraceEnabled())
             log.trace("getEdges from table: " + metadataTableName);
         // unlike other entries, the edges colf entries have many auths set. We'll use the fullUserAuths in the scanner instead
         // of the minimal set in this.auths
         Scanner scanner = ScannerHelper.createScanner(connector, metadataTableName, fullUserAuths);
-
+        
         scanner.setRange(new Range());
         scanner.fetchColumnFamily(ColumnFamilyConstants.COLF_EDGE);
-
+        
         // First iterator strips the optional attribute2 and attribute3 off the cq, second one
         // combines the protocol buffer data.
         IteratorSetting stripConfig = new IteratorSetting(50, EdgeMetadataCQStrippingIterator.class);
@@ -909,29 +911,30 @@ public class MetadataHelper {
         combineConfig.addOption("columns", ColumnFamilyConstants.COLF_EDGE.toString());
         scanner.addScanIterator(stripConfig);
         scanner.addScanIterator(combineConfig);
-
-        for (Map.Entry<Key, Value> entry : scanner) {
+        
+        for (Map.Entry<Key,Value> entry : scanner) {
             edges.put(entry.getKey(), entry.getValue());
         }
-
+        
         return Multimaps.unmodifiableSetMultimap(edges);
     }
-
+    
     /**
      * Fetch the set of {@link Type}s that are configured for this <code>fieldName</code> as specified in the table pointed to by the
      * <code>metadataTableName</code> parameter.
      *
-     * @param ingestTypeFilter Any projection of datatypes to limit the fetch for.
+     * @param ingestTypeFilter
+     *            Any projection of datatypes to limit the fetch for.
      * @return
      * @throws InstantiationException
      * @throws IllegalAccessException
      * @throws TableNotFoundException
      */
-    public Multimap<String, Type<?>> getFieldsToDatatypes(Set<String> ingestTypeFilter)
-            throws InstantiationException, IllegalAccessException, TableNotFoundException {
+    public Multimap<String,Type<?>> getFieldsToDatatypes(Set<String> ingestTypeFilter)
+                    throws InstantiationException, IllegalAccessException, TableNotFoundException {
         return this.allFieldMetadataHelper.getFieldsToDatatypes(ingestTypeFilter);
     }
-
+    
     /**
      * Scans the metadata table and returns the set of fields that use the supplied normalizer.
      *
@@ -942,10 +945,10 @@ public class MetadataHelper {
      * @throws TableNotFoundException
      */
     public Set<String> getFieldsForDatatype(Class<? extends Type<?>> datawaveType)
-            throws InstantiationException, IllegalAccessException, TableNotFoundException {
+                    throws InstantiationException, IllegalAccessException, TableNotFoundException {
         return getFieldsForDatatype(datawaveType, null);
     }
-
+    
     /**
      * Scans the metadata table and returns the set of fields that use the supplied normalizer.
      * <p>
@@ -960,11 +963,12 @@ public class MetadataHelper {
     public Set<String> getFieldsForDatatype(Class<? extends Type<?>> datawaveType, Set<String> ingestTypeFilter) throws TableNotFoundException {
         return this.allFieldMetadataHelper.getFieldsForDatatype(datawaveType, ingestTypeFilter);
     }
-
+    
     /**
      * Pull an instance of the provided normalizer class name from the internal cache.
      *
-     * @param datatypeClass The name of the normalizer class to instantiate.
+     * @param datatypeClass
+     *            The name of the normalizer class to instantiate.
      * @return An instanace of the normalizer class that was requested.
      * @throws InstantiationException
      * @throws IllegalAccessException
@@ -972,7 +976,7 @@ public class MetadataHelper {
     public Type<?> getDatatypeFromClass(Class<? extends Type<?>> datatypeClass) throws InstantiationException, IllegalAccessException {
         return this.allFieldMetadataHelper.getDatatypeFromClass(datatypeClass);
     }
-
+    
     /**
      * Fetch the Set of all fields marked as containing term frequency information, {@link ColumnFamilyConstants#COLF_TF}.
      *
@@ -981,11 +985,11 @@ public class MetadataHelper {
      */
     @Cacheable(value = "getTermFrequencyFields", key = "{#root.target.auths,#root.target.metadataTableName,#p0}", cacheManager = "metadataHelperCacheManager")
     public Set<String> getTermFrequencyFields(Set<String> ingestTypeFilter) throws TableNotFoundException {
-        Multimap<String, String> termFrequencyFields = loadTermFrequencyFields();
-
+        Multimap<String,String> termFrequencyFields = loadTermFrequencyFields();
+        
         return getFields(termFrequencyFields, ingestTypeFilter);
     }
-
+    
     /**
      * Get index fields using the data type filter.
      *
@@ -994,11 +998,11 @@ public class MetadataHelper {
      * @throws TableNotFoundException
      */
     public Set<String> getIndexedFields(Set<String> ingestTypeFilter) throws TableNotFoundException {
-        Multimap<String, String> indexedFields = this.allFieldMetadataHelper.loadIndexedFields();
-
+        Multimap<String,String> indexedFields = this.allFieldMetadataHelper.loadIndexedFields();
+        
         return getFields(indexedFields, ingestTypeFilter);
     }
-
+    
     /**
      * Get reverse index fields using the data type filter.
      *
@@ -1007,11 +1011,11 @@ public class MetadataHelper {
      * @throws TableNotFoundException
      */
     public Set<String> getReverseIndexedFields(Set<String> ingestTypeFilter) throws TableNotFoundException {
-        Multimap<String, String> reverseIndexedFields = this.allFieldMetadataHelper.loadReverseIndexedFields();
-
+        Multimap<String,String> reverseIndexedFields = this.allFieldMetadataHelper.loadReverseIndexedFields();
+        
         return getFields(reverseIndexedFields, ingestTypeFilter);
     }
-
+    
     /**
      * Get expansion fields using the data type filter.
      *
@@ -1020,11 +1024,11 @@ public class MetadataHelper {
      * @throws TableNotFoundException
      */
     public Set<String> getExpansionFields(Set<String> ingestTypeFilter) throws TableNotFoundException {
-        Multimap<String, String> expansionFields = this.allFieldMetadataHelper.loadExpansionFields();
-
+        Multimap<String,String> expansionFields = this.allFieldMetadataHelper.loadExpansionFields();
+        
         return getFields(expansionFields, ingestTypeFilter);
     }
-
+    
     /**
      * Get the content fields which are those to be queried when using the content functions.
      *
@@ -1033,12 +1037,12 @@ public class MetadataHelper {
      * @throws TableNotFoundException
      */
     public Set<String> getContentFields(Set<String> ingestTypeFilter) throws TableNotFoundException {
-        Multimap<String, String> contentFields = this.allFieldMetadataHelper.loadContentFields();
-
+        Multimap<String,String> contentFields = this.allFieldMetadataHelper.loadContentFields();
+        
         return getFields(contentFields, ingestTypeFilter);
     }
-
-    private Set<String> getFields(Multimap<String, String> fields, Set<String> ingestTypeFilter) {
+    
+    private Set<String> getFields(Multimap<String,String> fields, Set<String> ingestTypeFilter) {
         Set<String> returnedFields = new HashSet<>();
         if (ingestTypeFilter == null) {
             returnedFields.addAll(fields.values());
@@ -1049,7 +1053,7 @@ public class MetadataHelper {
         } // non-null but empty typeFilters allow nothing
         return Collections.unmodifiableSet(returnedFields);
     }
-
+    
     /**
      * Sum all of the frequency counts for a field between a start and end date (inclusive)
      *
@@ -1062,7 +1066,7 @@ public class MetadataHelper {
     public long getCardinalityForField(String fieldName, Date begin, Date end) throws TableNotFoundException {
         return getCardinalityForField(fieldName, null, begin, end);
     }
-
+    
     /**
      * Sum all of the frequency counts for a field in a datatype between a start and end date (inclusive)
      *
@@ -1076,20 +1080,20 @@ public class MetadataHelper {
     public long getCardinalityForField(String fieldName, String datatype, Date begin, Date end) throws TableNotFoundException {
         log.trace("getCardinalityForField from table: " + metadataTableName);
         Text row = new Text(fieldName.toUpperCase());
-
+        
         // Get all the rows in DatawaveMetadata for the field, only in the 'f'
         // colfam
         Scanner bs = ScannerHelper.createScanner(connector, metadataTableName, auths);
-
+        
         Key startKey = new Key(row);
         bs.setRange(new Range(startKey, startKey.followingKey(PartialKey.ROW)));
         bs.fetchColumnFamily(ColumnFamilyConstants.COLF_F);
-
+        
         long count = 0;
-
-        for (Entry<Key, Value> entry : bs) {
+        
+        for (Entry<Key,Value> entry : bs) {
             Text colq = entry.getKey().getColumnQualifier();
-
+            
             int index = colq.find(NULL_BYTE);
             if (index != -1) {
                 // If we were given a non-null datatype
@@ -1105,7 +1109,7 @@ public class MetadataHelper {
                         continue;
                     }
                 }
-
+                
                 // Parse the date to ensure that we want this record
                 String dateStr = "null";
                 Date date;
@@ -1126,35 +1130,35 @@ public class MetadataHelper {
                 }
             }
         }
-
+        
         bs.close();
-
+        
         return count;
     }
-
+    
     public Set<String> getDatatypes(Set<String> ingestTypeFilter) throws TableNotFoundException {
-
+        
         Set<String> datatypes = this.allFieldMetadataHelper.loadDatatypes();
         if (ingestTypeFilter != null && !ingestTypeFilter.isEmpty()) {
             datatypes = Sets.newHashSet(Sets.intersection(datatypes, ingestTypeFilter));
         }
-
+        
         return Collections.unmodifiableSet(datatypes);
     }
-
+    
     public Long getCountsByFieldForDays(String fieldName, Date begin, Date end) {
         return getCountsByFieldForDays(fieldName, begin, end, UniversalSet.instance());
     }
-
+    
     public Long getCountsByFieldForDays(String fieldName, Date begin, Date end, Set<String> ingestTypeFilter) {
         Preconditions.checkNotNull(fieldName);
         Preconditions.checkNotNull(begin);
         Preconditions.checkNotNull(end);
         Preconditions.checkArgument(begin.before(end));
-
+        
         Date truncatedBegin = DateUtils.truncate(begin, Calendar.DATE);
         Date truncatedEnd = DateUtils.truncate(end, Calendar.DATE);
-
+        
         if (truncatedEnd.getTime() != end.getTime()) {
             // If we don't have the same time for both, we actually truncated
             // the end,
@@ -1162,22 +1166,22 @@ public class MetadataHelper {
             // end
             truncatedEnd = new Date(truncatedEnd.getTime() + 86400000);
         }
-
+        
         Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
         cal.setTime(truncatedBegin);
-
+        
         long sum = 0l;
         while (cal.getTime().before(truncatedEnd)) {
             Date curDate = cal.getTime();
             String desiredDate = DateHelper.format(curDate);
-
+            
             sum += getCountsByFieldInDayWithTypes(fieldName, desiredDate, ingestTypeFilter);
             cal.add(Calendar.DATE, 1);
         }
-
+        
         return sum;
     }
-
+    
     /**
      * Return the sum across all datatypes of the {@link ColumnFamilyConstants#COLF_F} on the given day.
      *
@@ -1188,7 +1192,7 @@ public class MetadataHelper {
     public Long getCountsByFieldInDay(String fieldName, String date) {
         return getCountsByFieldInDayWithTypes(fieldName, date, UniversalSet.instance());
     }
-
+    
     /**
      * Return the sum across all datatypes of the {@link ColumnFamilyConstants#COLF_F} on the given day in the provided types
      *
@@ -1200,77 +1204,77 @@ public class MetadataHelper {
     public Long getCountsByFieldInDayWithTypes(String fieldName, String date, final Set<String> datatypes) {
         Preconditions.checkNotNull(fieldName);
         Preconditions.checkNotNull(date);
-
+        
         try {
-            Map<String, Long> countsByType = getCountsByFieldInDayWithTypes(Maps.immutableEntry(fieldName, date));
-
-            Iterable<Entry<String, Long>> filteredByType = datatypes == null ? countsByType.entrySet()
-                    : Iterables.filter(countsByType.entrySet(), input -> datatypes.contains(input.getKey()));
-
+            Map<String,Long> countsByType = getCountsByFieldInDayWithTypes(Maps.immutableEntry(fieldName, date));
+            
+            Iterable<Entry<String,Long>> filteredByType = datatypes == null ? countsByType.entrySet()
+                            : Iterables.filter(countsByType.entrySet(), input -> datatypes.contains(input.getKey()));
+            
             long sum = 0;
-            for (Entry<String, Long> entry : filteredByType) {
+            for (Entry<String,Long> entry : filteredByType) {
                 sum += entry.getValue();
             }
-
+            
             return sum;
         } catch (TableNotFoundException | IOException e) {
             throw new RuntimeException(e);
         }
     }
-
-    protected HashMap<String, Long> getCountsByFieldInDayWithTypes(Entry<String, String> identifier) throws TableNotFoundException, IOException {
+    
+    protected HashMap<String,Long> getCountsByFieldInDayWithTypes(Entry<String,String> identifier) throws TableNotFoundException, IOException {
         String fieldName = identifier.getKey();
         String date = identifier.getValue();
-
+        
         // try to get the counts by field using the original (cached) connector
-        HashMap<String, Long> datatypeToCounts = getCountsByFieldInDayWithTypes(fieldName, date, connector, null);
-
+        HashMap<String,Long> datatypeToCounts = getCountsByFieldInDayWithTypes(fieldName, date, connector, null);
+        
         // if we don't get a hit, try the real connector
         if (datatypeToCounts.isEmpty() && connector instanceof WrappedConnector) {
             WrappedConnector wrappedConnector = ((WrappedConnector) connector);
             datatypeToCounts = getCountsByFieldInDayWithTypes(fieldName, date, wrappedConnector.getReal(), wrappedConnector);
         }
-
+        
         return datatypeToCounts;
     }
-
-    protected HashMap<String, Long> getCountsByFieldInDayWithTypes(String fieldName, String date, Connector connector, WrappedConnector wrappedConnector)
-            throws TableNotFoundException, IOException {
-        final HashMap<String, Long> datatypeToCounts = Maps.newHashMap();
-
+    
+    protected HashMap<String,Long> getCountsByFieldInDayWithTypes(String fieldName, String date, Connector connector, WrappedConnector wrappedConnector)
+                    throws TableNotFoundException, IOException {
+        final HashMap<String,Long> datatypeToCounts = Maps.newHashMap();
+        
         BatchWriter writer = null;
-
+        
         try {
             // we have to use the real connector since the f column is not cached
             Scanner scanner = ScannerHelper.createScanner(connector, metadataTableName, auths);
             scanner.fetchColumnFamily(ColumnFamilyConstants.COLF_F);
             scanner.setRange(Range.exact(fieldName));
-
+            
             IteratorSetting cqRegex = new IteratorSetting(50, RegExFilter.class);
             RegExFilter.setRegexs(cqRegex, null, null, ".*\u0000" + date, null, false);
             scanner.addScanIterator(cqRegex);
-
+            
             final Text holder = new Text();
-            for (Entry<Key, Value> entry : scanner) {
+            for (Entry<Key,Value> entry : scanner) {
                 // if this is the real connector, and wrapped connector is not null, it means
                 // that we didn't get a hit in the cache. So, we will update the cache with the
                 // entries from the real table
                 if (wrappedConnector != null && connector == wrappedConnector.getReal()) {
                     writer = updateCache(entry, writer, wrappedConnector);
                 }
-
+                
                 ByteArrayInputStream bais = new ByteArrayInputStream(entry.getValue().get());
                 DataInputStream inputStream = new DataInputStream(bais);
-
+                
                 Long sum = WritableUtils.readVLong(inputStream);
-
+                
                 entry.getKey().getColumnQualifier(holder);
                 int offset = holder.find(NULL_BYTE);
-
+                
                 Preconditions.checkArgument(-1 != offset, "Could not find nullbyte separator in column qualifier for: " + entry.getKey());
-
+                
                 String datatype = Text.decode(holder.getBytes(), 0, offset);
-
+                
                 datatypeToCounts.put(datatype, sum);
             }
         } finally {
@@ -1282,56 +1286,56 @@ public class MetadataHelper {
                 }
             }
         }
-
+        
         return datatypeToCounts;
     }
-
+    
     public Date getEarliestOccurrenceOfField(String fieldName) {
         return getEarliestOccurrenceOfFieldWithType(fieldName, null);
     }
-
+    
     public Date getEarliestOccurrenceOfFieldWithType(String fieldName, final String dataType) {
         // try to get the date using the original (cached) connector
         Date date = getEarliestOccurrenceOfFieldWithType(fieldName, dataType, connector, null);
-
+        
         // if we don't get a hit, try the real connector
         if (date == null && connector instanceof WrappedConnector) {
             WrappedConnector wrappedConnector = ((WrappedConnector) connector);
             date = getEarliestOccurrenceOfFieldWithType(fieldName, dataType, wrappedConnector.getReal(), wrappedConnector);
         }
-
+        
         return date;
     }
-
+    
     protected Date getEarliestOccurrenceOfFieldWithType(String fieldName, final String dataType, Connector connector, WrappedConnector wrappedConnector) {
         String dateString = null;
         BatchWriter writer = null;
-
+        
         try {
             Scanner scanner = ScannerHelper.createScanner(connector, metadataTableName, auths);
             scanner.fetchColumnFamily(ColumnFamilyConstants.COLF_F);
             scanner.setRange(Range.exact(fieldName));
-
+            
             // if a type was specified, add a regex filter for it
             if (dataType != null) {
                 IteratorSetting cqRegex = new IteratorSetting(50, RegExFilter.class);
                 RegExFilter.setRegexs(cqRegex, null, null, dataType + "\u0000.*", null, false);
                 scanner.addScanIterator(cqRegex);
             }
-
+            
             try {
                 final Text holder = new Text();
-                for (Entry<Key, Value> entry : scanner) {
+                for (Entry<Key,Value> entry : scanner) {
                     // if this is the real connector, and wrapped connector is not null, it means
                     // that we didn't get a hit in the cache. So, we will update the cache with the
                     // entries from the real table
                     if (wrappedConnector != null && connector == wrappedConnector.getReal()) {
                         writer = updateCache(entry, writer, wrappedConnector);
                     }
-
+                    
                     entry.getKey().getColumnQualifier(holder);
                     int startPos = holder.find(NULL_BYTE) + 1;
-
+                    
                     if (0 == startPos) {
                         log.trace("Could not find nullbyte separator in column qualifier for: " + entry.getKey());
                     } else if ((holder.getLength() - startPos) <= 0) {
@@ -1359,44 +1363,47 @@ public class MetadataHelper {
                 }
             }
         }
-
+        
         Date date = null;
         if (dateString != null) {
             date = DateHelper.parse(dateString);
         }
-
+        
         return date;
     }
-
+    
     /**
      * Updates the table cache via the mock connector with the given entry and writer. If writer is null, a writer will be created and returned for subsequent
      * use.
      *
-     * @param entry            the entry to add
-     * @param writer           the batch writer
-     * @param wrappedConnector the wrapped connector
+     * @param entry
+     *            the entry to add
+     * @param writer
+     *            the batch writer
+     * @param wrappedConnector
+     *            the wrapped connector
      * @return a batch writer
      */
-    private BatchWriter updateCache(Entry<Key, Value> entry, BatchWriter writer, WrappedConnector wrappedConnector) {
+    private BatchWriter updateCache(Entry<Key,Value> entry, BatchWriter writer, WrappedConnector wrappedConnector) {
         try {
             if (writer == null) {
                 writer = wrappedConnector.getMock().createBatchWriter(metadataTableName, 10L * (1024L * 1024L), 100L, 1);
             }
-
+            
             Key valueKey = entry.getKey();
-
+            
             Mutation m = new Mutation(entry.getKey().getRow());
             m.put(valueKey.getColumnFamily(), valueKey.getColumnQualifier(), new ColumnVisibility(valueKey.getColumnVisibility()), valueKey.getTimestamp(),
-                    entry.getValue());
-
+                            entry.getValue());
+            
             writer.addMutation(m);
         } catch (MutationsRejectedException | TableNotFoundException e) {
             log.trace("Unable to add entry to cache for: " + entry.getKey());
         }
-
+        
         return writer;
     }
-
+    
     /**
      * Transform an Iterable of MetadataEntry's to just fieldName. This does not de-duplicate field names
      *
@@ -1406,7 +1413,7 @@ public class MetadataHelper {
     public static Iterable<String> fieldNames(Iterable<MetadataEntry> from) {
         return Iterables.transform(from, toFieldName);
     }
-
+    
     /**
      * Transform an Iterable of MetadataEntry's to just fieldName, removing duplicates.
      *
@@ -1416,7 +1423,7 @@ public class MetadataHelper {
     public static Set<String> uniqueFieldNames(Iterable<MetadataEntry> from) {
         return Sets.newHashSet(fieldNames(from));
     }
-
+    
     /**
      * Transform an Iterable of MetadataEntry's to just datatype. This does not de-duplicate datatypes
      *
@@ -1426,7 +1433,7 @@ public class MetadataHelper {
     public static Iterable<String> datatypes(Iterable<MetadataEntry> from) {
         return Iterables.transform(from, toDatatype);
     }
-
+    
     /**
      * Transform an Iterable of MetadataEntry's to just datatype, removing duplicates.
      *
@@ -1436,22 +1443,22 @@ public class MetadataHelper {
     public static Set<String> uniqueDatatypes(Iterable<MetadataEntry> from) {
         return Sets.newHashSet(datatypes(from));
     }
-
+    
     /**
      * Fetches the first entry from each row in the table. This equates to the set of all fields that have occurred in the database. Returns a multimap of
      * datatype to field
      *
      * @throws TableNotFoundException
      */
-    protected Multimap<String, String> loadAllFields() throws TableNotFoundException {
-        Multimap<String, String> fields = HashMultimap.create();
-
+    protected Multimap<String,String> loadAllFields() throws TableNotFoundException {
+        Multimap<String,String> fields = HashMultimap.create();
+        
         Scanner bs = ScannerHelper.createScanner(connector, metadataTableName, auths);
         if (log.isTraceEnabled())
             log.trace("loadAllFields from table: " + metadataTableName);
-
+        
         bs.setRange(new Range());
-
+        
         // We don't want to fetch all columns because that could include model
         // field names
         bs.fetchColumnFamily(ColumnFamilyConstants.COLF_T);
@@ -1460,32 +1467,32 @@ public class MetadataHelper {
         bs.fetchColumnFamily(ColumnFamilyConstants.COLF_RI);
         bs.fetchColumnFamily(ColumnFamilyConstants.COLF_TF);
         bs.fetchColumnFamily(ColumnFamilyConstants.COLF_CI);
-
-        Iterator<Entry<Key, Value>> iterator = bs.iterator();
-
+        
+        Iterator<Entry<Key,Value>> iterator = bs.iterator();
+        
         while (iterator.hasNext()) {
-            Entry<Key, Value> entry = iterator.next();
+            Entry<Key,Value> entry = iterator.next();
             Key k = entry.getKey();
-
+            
             String fieldname = k.getRow().toString();
             String datatype = getDatatype(k);
-
+            
             fields.put(datatype, fieldname);
         }
-
+        
         return Multimaps.unmodifiableMultimap(fields);
     }
-
+    
     /**
      * Fetches results from metadata table and calculates the set of fieldNames which are indexed but do not appear as an attribute on the Event Returns a
      * multimap of datatype to field
      *
      * @throws TableNotFoundException
      */
-    protected Multimap<String, String> loadIndexOnlyFields() throws TableNotFoundException {
+    protected Multimap<String,String> loadIndexOnlyFields() throws TableNotFoundException {
         return this.allFieldMetadataHelper.getIndexOnlyFields();
     }
-
+    
     /**
      * Fetch the Set of all fields marked as containing term frequency information, {@link ColumnFamilyConstants#COLF_TF}. Returns a multimap of datatype to
      * field
@@ -1493,57 +1500,57 @@ public class MetadataHelper {
      * @return
      * @throws TableNotFoundException
      */
-    protected Multimap<String, String> loadTermFrequencyFields() throws TableNotFoundException {
-        Multimap<String, String> fields = HashMultimap.create();
+    protected Multimap<String,String> loadTermFrequencyFields() throws TableNotFoundException {
+        Multimap<String,String> fields = HashMultimap.create();
         if (log.isTraceEnabled())
             log.trace("loadTermFrequencyFields from table: " + metadataTableName);
         // Scanner to the provided metadata table
         Scanner bs = ScannerHelper.createScanner(connector, metadataTableName, auths);
-
+        
         bs.setRange(new Range());
         bs.fetchColumnFamily(ColumnFamilyConstants.COLF_TF);
-
-        for (Entry<Key, Value> entry : bs) {
+        
+        for (Entry<Key,Value> entry : bs) {
             fields.put(getDatatype(entry.getKey()), entry.getKey().getRow().toString());
         }
-
+        
         return Multimaps.unmodifiableMultimap(fields);
     }
-
+    
     private static String getKey(Instance instance, String metadataTableName) {
         StringBuilder builder = new StringBuilder();
         builder.append(instance != null ? instance.getInstanceID() : null).append('\0');
         builder.append(metadataTableName).append('\0');
         return builder.toString();
     }
-
+    
     private static String getKey(MetadataHelper helper) {
         return getKey(helper.instance, helper.metadataTableName);
     }
-
+    
     @Override
     public String toString() {
         return getKey(this);
     }
-
+    
     public static void basicIterator(Connector connector, String tableName, Collection<Authorizations> auths)
-            throws TableNotFoundException, InvalidProtocolBufferException {
+                    throws TableNotFoundException, InvalidProtocolBufferException {
         if (log.isTraceEnabled())
             log.trace("--- basicIterator ---" + tableName);
         Scanner scanner = connector.createScanner(tableName, auths.iterator().next());
         Range range = new Range();
         scanner.setRange(range);
-        Iterator<Entry<Key, Value>> iter = scanner.iterator();
+        Iterator<Entry<Key,Value>> iter = scanner.iterator();
         while (iter.hasNext()) {
-            Entry<Key, Value> entry = iter.next();
+            Entry<Key,Value> entry = iter.next();
             Key k = entry.getKey();
             if (log.isTraceEnabled())
                 log.trace("Key: " + k);
         }
     }
-
+    
     public String getMetadataTableName() {
         return metadataTableName;
     }
-
+    
 }

--- a/src/main/java/datawave/query/util/MetadataHelper.java
+++ b/src/main/java/datawave/query/util/MetadataHelper.java
@@ -97,13 +97,13 @@ import java.util.stream.StreamSupport;
 @Scope("prototype")
 public class MetadataHelper {
     private static final Logger log = LoggerFactory.getLogger(MetadataHelper.class);
-    
+
     public static final String NULL_BYTE = "\0";
-    
+
     protected static final Text PV = new Text("pv");
-    
-    protected static final Function<MetadataEntry,String> toFieldName = new MetadataEntryToFieldName(), toDatatype = new MetadataEntryToDatatype();
-    
+
+    protected static final Function<MetadataEntry, String> toFieldName = new MetadataEntryToFieldName(), toDatatype = new MetadataEntryToDatatype();
+
     protected String getDatatype(Key k) {
         String datatype = k.getColumnQualifier().toString();
         int index = datatype.indexOf('\0');
@@ -112,52 +112,52 @@ public class MetadataHelper {
         }
         return datatype;
     }
-    
+
     protected final Metadata metadata = new Metadata();
-    
+
     protected final List<Text> metadataIndexColfs = Arrays.asList(ColumnFamilyConstants.COLF_I, ColumnFamilyConstants.COLF_RI);
     protected final List<Text> metadataNormalizedColfs = Arrays.asList(ColumnFamilyConstants.COLF_N);
     protected final List<Text> metadataTypeColfs = Arrays.asList(ColumnFamilyConstants.COLF_T);
     protected final List<Text> metadataCompositeIndexColfs = Arrays.asList(ColumnFamilyConstants.COLF_CI);
     protected final List<Text> metadataCardinalityColfs = Arrays.asList(ColumnFamilyConstants.COLF_COUNT);
-    
+
     protected final Connector connector;
     protected final Instance instance;
     protected final String metadataTableName;
     protected final Set<Authorizations> auths;
     protected Set<Authorizations> fullUserAuths;
-    
+
     protected final AllFieldMetadataHelper allFieldMetadataHelper;
     protected final Collection<Authorizations> allMetadataAuths;
-    
+
     // a set of fields that are dynamically created at evaluation time, and are not registered in the metadata table
     protected Set<String> evaluationOnlyFields = Collections.emptySet();
-    
+
     public MetadataHelper(AllFieldMetadataHelper allFieldMetadataHelper, Collection<Authorizations> allMetadataAuths, Connector connector,
-                    String metadataTableName, Set<Authorizations> auths, Set<Authorizations> fullUserAuths) {
+                          String metadataTableName, Set<Authorizations> auths, Set<Authorizations> fullUserAuths) {
         Preconditions.checkNotNull(allFieldMetadataHelper, "An AllFieldMetadataHelper is required by MetadataHelper");
         this.allFieldMetadataHelper = allFieldMetadataHelper;
-        
+
         Preconditions.checkNotNull(allMetadataAuths, "The set of all metadata authorization is required by MetadataHelper");
         this.allMetadataAuths = allMetadataAuths;
-        
+
         Preconditions.checkNotNull(connector, "A valid Accumulo Connector is required by MetadataHelper");
         this.connector = connector;
         this.instance = connector.getInstance();
-        
+
         Preconditions.checkNotNull(metadataTableName, "The name of the metadata table is required by MetadataHelper");
         this.metadataTableName = metadataTableName;
-        
+
         Preconditions.checkNotNull(auths, "Authorizations are required by MetadataHelper");
         this.auths = auths;
-        
+
         Preconditions.checkNotNull(fullUserAuths, "The full set of user authorizations is required by MetadataHelper");
         this.fullUserAuths = fullUserAuths;
         log.debug("initialized with auths subset: {}", this.auths);
-        
+
         log.trace("Constructor connector: {} with auths: {} and metadata table name: {}", connector.getClass().getCanonicalName(), auths, metadataTableName);
     }
-    
+
     /**
      * allMetadataAuths is a singleton Collection of one Authorizations instance that contains all of the auths required to see everything in the Metadata
      * table. userAuths is a Collection of Authorizations, every one of which must contain th
@@ -167,7 +167,7 @@ public class MetadataHelper {
      * @return
      */
     public static boolean userHasAllMetadataAuths(Collection<Authorizations> usersAuthsCollection, Collection<Authorizations> allMetadataAuthsCollection) {
-        
+
         // first, minimize the usersAuths:
         Collection<Authorizations> minimizedCollection = AuthorizationsMinimizer.minimize(usersAuthsCollection);
         // now, the first entry in the minimized auths should have everything common to every Authorizations in the set
@@ -175,9 +175,9 @@ public class MetadataHelper {
         Authorizations allMetadataAuths = allMetadataAuthsCollection.iterator().next(); // get the first (and only) one
         Authorizations minimized = minimizedCollection.iterator().next(); // get the first one, which has all auths common to all in the original collection
         return StreamSupport.stream(minimized.spliterator(), false).map(String::new).collect(Collectors.toSet())
-                        .containsAll(StreamSupport.stream(allMetadataAuths.spliterator(), false).map(String::new).collect(Collectors.toSet()));
+                .containsAll(StreamSupport.stream(allMetadataAuths.spliterator(), false).map(String::new).collect(Collectors.toSet()));
     }
-    
+
     /**
      * allMetadataAuthsCollection is a singleton Collection of one Authorizations instance that contains all of the auths required to see everything in the
      * Metadata table. userAuthsCollection contains the user's auths. This method will return the retention of the user's auths from the
@@ -188,7 +188,7 @@ public class MetadataHelper {
      * @return
      */
     public static Collection<String> getUsersMetadataAuthorizationSubset(Collection<Authorizations> usersAuthsCollection,
-                    Collection<Authorizations> allMetadataAuthsCollection) {
+                                                                         Collection<Authorizations> allMetadataAuthsCollection) {
         if (log.isTraceEnabled()) {
             log.trace("allMetadataAuthsCollection:" + allMetadataAuthsCollection);
             log.trace("usersAuthsCollection:" + usersAuthsCollection);
@@ -198,7 +198,7 @@ public class MetadataHelper {
         if (log.isTraceEnabled()) {
             log.trace("minimizedCollection:" + minimizedCollection);
         }
-        
+
         // now, the first entry in the minimized auths should have everything common to every Authorizations in the set
         // make sure that the first entry contains all the Authorizations in the allMetadataAuths
         Authorizations allMetadataAuths = allMetadataAuthsCollection.iterator().next(); // get the first (and only) one
@@ -207,7 +207,7 @@ public class MetadataHelper {
             log.trace("first of users auths minimized:" + minimized);
         }
         Set<String> minimizedUserAuths = StreamSupport.stream(minimized.spliterator(), false).map(String::new).collect(Collectors.toSet());
-        
+
         Collection<String> minimizedAllMetadataAuths = StreamSupport.stream(allMetadataAuths.spliterator(), false).map(String::new).collect(Collectors.toSet());
         minimizedAllMetadataAuths.retainAll(minimizedUserAuths);
         if (log.isTraceEnabled()) {
@@ -215,9 +215,9 @@ public class MetadataHelper {
         }
         return minimizedAllMetadataAuths;
     }
-    
+
     private Set<Set<String>> getAllMetadataAuthsPowerSet(Collection<Authorizations> allMetadataAuthsCollection) {
-        
+
         // first, minimize the usersAuths:
         Collection<Authorizations> minimizedCollection = AuthorizationsMinimizer.minimize(allMetadataAuthsCollection);
         // now, the first entry in the minimized auths should have everything common to every Authorizations in the set
@@ -235,21 +235,21 @@ public class MetadataHelper {
         }
         return set;
     }
-    
-    public Map<Set<String>,TypeMetadata> getTypeMetadataMap() throws TableNotFoundException {
+
+    public Map<Set<String>, TypeMetadata> getTypeMetadataMap() throws TableNotFoundException {
         Collection<Set<String>> powerset = getAllMetadataAuthsPowerSet(this.allMetadataAuths);
         if (log.isTraceEnabled()) {
             log.trace("powerset:" + powerset);
         }
-        Map<Set<String>,TypeMetadata> map = Maps.newHashMap();
-        
+        Map<Set<String>, TypeMetadata> map = Maps.newHashMap();
+
         for (Set<String> a : powerset) {
             if (log.isTraceEnabled()) {
                 log.trace("get TypeMetadata with auths:" + a);
             }
-            
+
             Authorizations at = new Authorizations(a.toArray(new String[a.size()]));
-            
+
             if (log.isTraceEnabled()) {
                 log.trace("made an Authorizations:" + at);
             }
@@ -258,7 +258,7 @@ public class MetadataHelper {
         }
         return map;
     }
-    
+
     public String getUsersMetadataAuthorizationSubset() {
         StringBuilder buf = new StringBuilder();
         if (this.auths != null && this.allMetadataAuths != null) {
@@ -271,23 +271,23 @@ public class MetadataHelper {
         }
         return buf.toString();
     }
-    
+
     public Collection<Authorizations> getAllMetadataAuths() {
         return allMetadataAuths;
     }
-    
+
     public Set<Authorizations> getAuths() {
         return auths;
     }
-    
+
     public Set<Authorizations> getFullUserAuths() {
         return fullUserAuths;
     }
-    
+
     public AllFieldMetadataHelper getAllFieldMetadataHelper() {
         return this.allFieldMetadataHelper;
     }
-    
+
     /**
      * Get the metadata fully populated
      *
@@ -298,7 +298,7 @@ public class MetadataHelper {
     public Metadata getMetadata() throws TableNotFoundException, ExecutionException, MarkingFunctions.Exception {
         return getMetadata(null);
     }
-    
+
     /**
      * Get the metadata fully populated
      *
@@ -309,7 +309,7 @@ public class MetadataHelper {
     public Metadata getMetadata(Set<String> ingestTypeFilter) throws TableNotFoundException, ExecutionException, MarkingFunctions.Exception {
         return new Metadata(this, ingestTypeFilter);
     }
-    
+
     /**
      * Fetch the {@link Set} of all fields contained in the database. This will provide a cached view of the fields which is updated every
      * {@code updateInterval} milliseconds.
@@ -318,28 +318,30 @@ public class MetadataHelper {
      * @throws TableNotFoundException
      */
     public Set<String> getAllFields(Set<String> ingestTypeFilter) throws TableNotFoundException {
-        Multimap<String,String> allFields = this.allFieldMetadataHelper.loadAllFields();
+        Multimap<String, String> allFields = this.allFieldMetadataHelper.loadAllFields();
         if (log.isTraceEnabled())
             log.trace("loadAllFields() with auths:" + this.allFieldMetadataHelper.getAuths() + " returned " + allFields);
-        
+
         Set<String> fields = getFields(allFields, ingestTypeFilter);
-        
+
         // Add any additional fields that are created at evaluation time and are hence not in the metadata table.
-        fields.addAll(evaluationOnlyFields);
-        
+        if (!evaluationOnlyFields.isEmpty()) {
+            fields.addAll(evaluationOnlyFields);
+        }
+
         if (log.isTraceEnabled())
             log.trace("getAllFields(" + ingestTypeFilter + ") returning " + fields);
         return Collections.unmodifiableSet(fields);
     }
-    
+
     public Set<String> getEvaluationOnlyFields() {
         return Collections.unmodifiableSet(evaluationOnlyFields);
     }
-    
+
     public void setEvaluationOnlyFields(Set<String> evaluationOnlyFields) {
         this.evaluationOnlyFields = (evaluationOnlyFields == null ? Collections.emptySet() : new HashSet<>(evaluationOnlyFields));
     }
-    
+
     /**
      * Get the fields that have values not in the same form as the event (excluding normalization). This would include index only fields, term frequency fields
      * (as the index may contain tokens), and composite fields.
@@ -348,11 +350,11 @@ public class MetadataHelper {
      * @return the non-event fields
      */
     public Set<String> getNonEventFields(Set<String> ingestTypeFilter) throws TableNotFoundException {
-        
+
         Set<String> fields = new HashSet<>();
         fields.addAll(getIndexOnlyFields(ingestTypeFilter));
         fields.addAll(getTermFrequencyFields(ingestTypeFilter));
-        Multimap<String,String> compToFieldMap = getCompositeToFieldMap(ingestTypeFilter);
+        Multimap<String, String> compToFieldMap = getCompositeToFieldMap(ingestTypeFilter);
         for (String compField : compToFieldMap.keySet()) {
             if (!isOverloadedCompositeField(compToFieldMap, compField)) {
                 // a composite is only a non-event field if it is composed from 1 or more non-event fields
@@ -364,20 +366,20 @@ public class MetadataHelper {
                 }
             }
         }
-        
+
         return Collections.unmodifiableSet(fields);
     }
-    
-    static boolean isOverloadedCompositeField(Multimap<String,String> compositeFieldDefinitions, String compositeFieldName) {
+
+    static boolean isOverloadedCompositeField(Multimap<String, String> compositeFieldDefinitions, String compositeFieldName) {
         return isOverloadedCompositeField(compositeFieldDefinitions.get(compositeFieldName), compositeFieldName);
     }
-    
+
     static boolean isOverloadedCompositeField(Collection<String> compFields, String compositeFieldName) {
         if (compFields != null && !compFields.isEmpty())
             return compFields.stream().findFirst().get().equals(compositeFieldName);
         return false;
     }
-    
+
     /**
      * Fetch the {@link Set} of index-only fields.
      *
@@ -385,51 +387,51 @@ public class MetadataHelper {
      * @throws TableNotFoundException
      */
     public Set<String> getIndexOnlyFields(Set<String> ingestTypeFilter) throws TableNotFoundException {
-        
-        Multimap<String,String> indexOnlyFields = this.allFieldMetadataHelper.getIndexOnlyFields();
-        
+
+        Multimap<String, String> indexOnlyFields = this.allFieldMetadataHelper.getIndexOnlyFields();
+
         return getFields(indexOnlyFields, ingestTypeFilter);
     }
-    
+
     public QueryModel getQueryModel(String modelTableName, String modelName) throws TableNotFoundException, ExecutionException {
         return getQueryModel(modelTableName, modelName, this.getIndexOnlyFields(null));
     }
-    
+
     public QueryModel getQueryModel(String modelTableName, String modelName, Collection<String> unevaluatedFields) throws TableNotFoundException {
         return getQueryModel(modelTableName, modelName, unevaluatedFields, null);
     }
-    
+
     /***
      * @param modelName
      * @return
      * @throws TableNotFoundException
      */
     public QueryModel getQueryModel(String modelTableName, String modelName, Collection<String> unevaluatedFields, Set<String> ingestTypeFilter)
-                    throws TableNotFoundException {
+            throws TableNotFoundException {
         // Note that we used to cache this, however this method is dependent on some variables in the all fields metadata helper
         // @Cacheable(value = "getQueryModel", key = "{#root.target.auths,#p0,#p1,#p2,#p3}", cacheManager = "metadataHelperCacheManager")
-        
+
         Preconditions.checkNotNull(modelTableName);
         Preconditions.checkNotNull(modelName);
-        
+
         if (log.isTraceEnabled())
             log.trace("getQueryModel(" + modelTableName + "," + modelName + "," + unevaluatedFields + "," + ingestTypeFilter + ")");
         QueryModel queryModel = new QueryModel();
-        
+
         TraceStopwatch stopWatch = new TraceStopwatch("MetadataHelper -- Building Query Model from instance");
         stopWatch.start();
-        
+
         if (log.isTraceEnabled())
             log.trace("using connector: " + connector.getClass().getCanonicalName() + " with auths: " + auths + " and model table name: " + modelTableName
-                            + " looking at model " + modelName + " unevaluatedFields " + unevaluatedFields);
-        
+                    + " looking at model " + modelName + " unevaluatedFields " + unevaluatedFields);
+
         Scanner scan = ScannerHelper.createScanner(connector, modelTableName, auths);
         scan.setRange(new Range());
         scan.fetchColumnFamily(new Text(modelName));
         // We need the entire Model so we can do both directions.
         final Set<String> allFields = this.getAllFields(ingestTypeFilter);
-        
-        for (Map.Entry<Key,Value> entry : scan) {
+
+        for (Map.Entry<Key, Value> entry : scan) {
             try {
                 FieldMapping mapping = ModelKeyParser.parseKey(entry.getKey());
                 if (mapping.isLenient()) {
@@ -441,7 +443,7 @@ public class MetadataHelper {
                         queryModel.addTermToModel(mapping.getModelFieldName(), mapping.getFieldName());
                     } else if (log.isTraceEnabled()) {
                         log.trace("Ignoring forward mapping of " + mapping.getFieldName() + " for " + mapping.getModelFieldName()
-                                        + " because the metadata table has no reference to it");
+                                + " because the metadata table has no reference to it");
                     }
                 } else {
                     queryModel.addTermToReverseModel(mapping.getFieldName(), mapping.getModelFieldName());
@@ -450,7 +452,7 @@ public class MetadataHelper {
                 log.warn("Ignoring unparseable key " + entry.getKey());
             }
         }
-        
+
         if (queryModel.getReverseQueryMapping().isEmpty()) {
             if (log.isTraceEnabled()) {
                 log.trace("empty query model for " + this);
@@ -459,12 +461,12 @@ public class MetadataHelper {
                 log.error("Query Model should not be empty...");
             }
         }
-        
+
         stopWatch.stop();
-        
+
         return queryModel;
     }
-    
+
     /***
      * @param modelTableName
      * @return a list of query model names
@@ -473,16 +475,16 @@ public class MetadataHelper {
     @Cacheable(value = "getQueryModelNames", key = "{#root.target.auths,#table}", cacheManager = "metadataHelperCacheManager")
     public Set<String> getQueryModelNames(String modelTableName) throws TableNotFoundException {
         Preconditions.checkNotNull(modelTableName);
-        
+
         if (log.isTraceEnabled())
             log.trace("getQueryModelNames(" + modelTableName + ")");
-        
+
         TraceStopwatch stopWatch = new TraceStopwatch("MetadataHelper -- Getting query model names");
         stopWatch.start();
-        
+
         if (log.isTraceEnabled())
             log.trace("using connector: " + connector.getClass().getCanonicalName() + " with auths: " + auths + " and model table name: " + modelTableName);
-        
+
         Scanner scan = ScannerHelper.createScanner(connector, modelTableName, auths);
         scan.setRange(new Range());
         Set<String> modelNames = new HashSet<>();
@@ -501,8 +503,8 @@ public class MetadataHelper {
         ignoreColfs.add(ColumnFamilyConstants.COLF_TF);
         ignoreColfs.add(ColumnFamilyConstants.COLF_VERSION);
         ignoreColfs.add(ColumnFamilyConstants.COLF_EXP);
-        
-        for (Map.Entry<Key,Value> entry : scan) {
+
+        for (Map.Entry<Key, Value> entry : scan) {
             Text cf = entry.getKey().getColumnFamily();
             if (!ignoreColfs.contains(entry.getKey().getColumnFamily())) {
                 if (entry.getKey().getColumnQualifier().toString().endsWith("\0forward")) {
@@ -510,12 +512,12 @@ public class MetadataHelper {
                 }
             }
         }
-        
+
         stopWatch.stop();
-        
+
         return modelNames;
     }
-    
+
     /**
      * Determines whether a field has been reverse indexed by looking for the ri column in the metadata table
      *
@@ -526,16 +528,16 @@ public class MetadataHelper {
      */
     public boolean isReverseIndexed(String fieldName, Set<String> ingestTypeFilter) throws TableNotFoundException {
         Preconditions.checkNotNull(fieldName);
-        
-        Entry<String,Entry<String,Set<String>>> entry = Maps.immutableEntry(metadataTableName, Maps.immutableEntry(fieldName, ingestTypeFilter));
-        
+
+        Entry<String, Entry<String, Set<String>>> entry = Maps.immutableEntry(metadataTableName, Maps.immutableEntry(fieldName, ingestTypeFilter));
+
         try {
             return this.allFieldMetadataHelper.isIndexed(ColumnFamilyConstants.COLF_RI, entry);
         } catch (InstantiationException | ExecutionException e) {
             throw new RuntimeException(e);
         }
     }
-    
+
     /**
      * Determines whether a field has been indexed by looking for the i column in the metadata table
      *
@@ -546,17 +548,17 @@ public class MetadataHelper {
      */
     public boolean isIndexed(String fieldName, Set<String> ingestTypeFilter) throws TableNotFoundException {
         Preconditions.checkNotNull(fieldName);
-        
-        Entry<String,Entry<String,Set<String>>> entry = Maps.immutableEntry(metadataTableName, Maps.immutableEntry(fieldName, ingestTypeFilter));
-        
+
+        Entry<String, Entry<String, Set<String>>> entry = Maps.immutableEntry(metadataTableName, Maps.immutableEntry(fieldName, ingestTypeFilter));
+
         try {
             return this.allFieldMetadataHelper.isIndexed(ColumnFamilyConstants.COLF_I, entry);
         } catch (InstantiationException | ExecutionException e) {
             throw new RuntimeException(e);
         }
-        
+
     }
-    
+
     /**
      * Determines whether a field has been tokenized by looking for the tf column in the metadata table
      *
@@ -567,16 +569,16 @@ public class MetadataHelper {
      */
     public boolean isTokenized(String fieldName, Set<String> ingestTypeFilter) throws TableNotFoundException {
         Preconditions.checkNotNull(fieldName);
-        
-        Entry<String,Entry<String,Set<String>>> entry = Maps.immutableEntry(metadataTableName, Maps.immutableEntry(fieldName, ingestTypeFilter));
-        
+
+        Entry<String, Entry<String, Set<String>>> entry = Maps.immutableEntry(metadataTableName, Maps.immutableEntry(fieldName, ingestTypeFilter));
+
         try {
             return this.allFieldMetadataHelper.isIndexed(ColumnFamilyConstants.COLF_TF, entry);
         } catch (InstantiationException | ExecutionException e) {
             throw new RuntimeException(e);
         }
     }
-    
+
     /**
      * Returns a Set of all TextNormalizers in use by any type in Accumulo
      *
@@ -586,20 +588,20 @@ public class MetadataHelper {
      * @throws TableNotFoundException
      */
     @Cacheable(value = "getFacets", key = "{#root.target.auths,#table}", cacheManager = "metadataHelperCacheManager")
-    public Multimap<String,String> getFacets(String table) throws InstantiationException, IllegalAccessException, TableNotFoundException {
+    public Multimap<String, String> getFacets(String table) throws InstantiationException, IllegalAccessException, TableNotFoundException {
         log.debug("cache fault for getFacets(" + this.auths + "," + table + ")");
-        Multimap<String,String> fieldPivots = HashMultimap.create();
-        
+        Multimap<String, String> fieldPivots = HashMultimap.create();
+
         Scanner bs = ScannerHelper.createScanner(connector, table, auths);
         Range range = new Range();
-        
+
         bs.setRange(range);
-        
+
         bs.fetchColumnFamily(PV);
-        
-        for (Entry<Key,Value> entry : bs) {
+
+        for (Entry<Key, Value> entry : bs) {
             Key key = entry.getKey();
-            
+
             if (null != key.getRow()) {
                 String[] parts = StringUtils.split(key.getRow().toString(), "\0");
                 if (parts.length == 2) {
@@ -611,10 +613,10 @@ public class MetadataHelper {
                 log.warn("Row null in ColumnFamilyConstants for key: " + key);
             }
         }
-        
+
         return fieldPivots;
     }
-    
+
     /**
      * Returns a Set of all counts / cardinalities
      *
@@ -624,30 +626,30 @@ public class MetadataHelper {
      * @throws TableNotFoundException
      */
     @Cacheable(value = "getTermCounts", key = "{#root.target.auths,#root.target.metadataTableName}", cacheManager = "metadataHelperCacheManager")
-    public Map<String,Map<String,MetadataCardinalityCounts>> getTermCounts() throws InstantiationException, IllegalAccessException, TableNotFoundException {
+    public Map<String, Map<String, MetadataCardinalityCounts>> getTermCounts() throws InstantiationException, IllegalAccessException, TableNotFoundException {
         log.debug("cache fault for getTermCounts(" + this.auths + "," + this.metadataTableName + ")");
-        Map<String,Map<String,MetadataCardinalityCounts>> allCounts = Maps.newHashMap();
-        
+        Map<String, Map<String, MetadataCardinalityCounts>> allCounts = Maps.newHashMap();
+
         if (log.isTraceEnabled())
             log.trace("getTermCounts from table: " + metadataTableName);
-        
+
         Scanner bs = ScannerHelper.createScanner(connector, metadataTableName, auths);
         Range range = new Range();
-        
+
         bs.setRange(range);
-        
+
         // Fetch all of the index columns
         for (Text colf : metadataCardinalityColfs) {
             bs.fetchColumnFamily(colf);
         }
-        
+
         try {
-            for (Entry<Key,Value> entry : bs) {
+            for (Entry<Key, Value> entry : bs) {
                 Key key = entry.getKey();
-                
+
                 if (null != key.getRow()) {
                     MetadataCardinalityCounts counts = new MetadataCardinalityCounts(key, entry.getValue());
-                    Map<String,MetadataCardinalityCounts> values = allCounts.get(counts.getField());
+                    Map<String, MetadataCardinalityCounts> values = allCounts.get(counts.getField());
                     if (values == null) {
                         values = Maps.newHashMapWithExpectedSize(5);
                         allCounts.put(counts.getField(), values);
@@ -660,10 +662,10 @@ public class MetadataHelper {
         } finally {
             bs.close();
         }
-        
+
         return Collections.unmodifiableMap(allCounts);
     }
-    
+
     /**
      * Returns a Set of all Counts using the connector's principal's auths. This resulting informations cannot be exposed outside of the system.
      *
@@ -673,33 +675,33 @@ public class MetadataHelper {
      * @throws TableNotFoundException
      */
     @Cacheable(value = "getTermCountsWithRootAuths", key = "{#root.target.metadataTableName}", cacheManager = "metadataHelperCacheManager")
-    public Map<String,Map<String,MetadataCardinalityCounts>> getTermCountsWithRootAuths()
-                    throws InstantiationException, IllegalAccessException, TableNotFoundException, AccumuloSecurityException, AccumuloException {
+    public Map<String, Map<String, MetadataCardinalityCounts>> getTermCountsWithRootAuths()
+            throws InstantiationException, IllegalAccessException, TableNotFoundException, AccumuloSecurityException, AccumuloException {
         log.debug("cache fault for getTermCounts(" + this.auths + "," + this.metadataTableName + ")");
-        Map<String,Map<String,MetadataCardinalityCounts>> allCounts = Maps.newHashMap();
-        
+        Map<String, Map<String, MetadataCardinalityCounts>> allCounts = Maps.newHashMap();
+
         if (log.isTraceEnabled())
             log.trace("getTermCounts from table: " + metadataTableName);
-        
+
         Authorizations rootAuths = connector.securityOperations().getUserAuthorizations(connector.whoami());
-        
+
         Scanner bs = ScannerHelper.createScanner(connector, metadataTableName, Collections.singleton(rootAuths));
         Range range = new Range();
-        
+
         bs.setRange(range);
-        
+
         // Fetch all of the index columns
         for (Text colf : metadataCardinalityColfs) {
             bs.fetchColumnFamily(colf);
         }
-        
+
         try {
-            for (Entry<Key,Value> entry : bs) {
+            for (Entry<Key, Value> entry : bs) {
                 Key key = entry.getKey();
-                
+
                 if (null != key.getRow()) {
                     MetadataCardinalityCounts counts = new MetadataCardinalityCounts(key, entry.getValue());
-                    Map<String,MetadataCardinalityCounts> values = allCounts.get(counts.getField());
+                    Map<String, MetadataCardinalityCounts> values = allCounts.get(counts.getField());
                     if (values == null) {
                         values = Maps.newHashMapWithExpectedSize(5);
                         allCounts.put(counts.getField(), values);
@@ -712,10 +714,10 @@ public class MetadataHelper {
         } finally {
             bs.close();
         }
-        
+
         return Collections.unmodifiableMap(allCounts);
     }
-    
+
     /**
      * Returns a Set of all TextNormalizers in use by any type in Accumulo
      *
@@ -730,21 +732,21 @@ public class MetadataHelper {
         Set<String> normalizedFields = Sets.newHashSetWithExpectedSize(10);
         if (log.isTraceEnabled())
             log.trace("getAllNormalized from table: " + metadataTableName);
-        
+
         Scanner bs = ScannerHelper.createScanner(connector, metadataTableName, auths);
         Range range = new Range();
-        
+
         bs.setRange(range);
-        
+
         // Fetch all of the index columns
         for (Text colf : metadataNormalizedColfs) {
             bs.fetchColumnFamily(colf);
         }
-        
+
         try {
-            for (Entry<Key,Value> entry : bs) {
+            for (Entry<Key, Value> entry : bs) {
                 Key key = entry.getKey();
-                
+
                 if (null != key.getRow()) {
                     normalizedFields.add(key.getRow().toString());
                 } else {
@@ -754,10 +756,10 @@ public class MetadataHelper {
         } finally {
             bs.close();
         }
-        
+
         return Collections.unmodifiableSet(normalizedFields);
     }
-    
+
     /**
      * Returns a Set of all Types in use by any type in Accumulo
      *
@@ -769,7 +771,7 @@ public class MetadataHelper {
     public Set<Type<?>> getAllDatatypes() throws InstantiationException, IllegalAccessException, TableNotFoundException {
         return this.allFieldMetadataHelper.getAllDatatypes();
     }
-    
+
     /**
      * A map of composite name to the ordered list of it for example, mapping of {@code COLOR -> ['COLOR_WHEELS,0', 'MAKE_COLOR,1' ]}. If called multiple time,
      * it returns the same cached map.
@@ -777,63 +779,62 @@ public class MetadataHelper {
      * @return An unmodifiable Multimap
      * @throws TableNotFoundException
      */
-    public Multimap<String,String> getCompositeToFieldMap() throws TableNotFoundException {
+    public Multimap<String, String> getCompositeToFieldMap() throws TableNotFoundException {
         return this.allFieldMetadataHelper.getCompositeToFieldMap();
     }
-    
-    public Multimap<String,String> getCompositeToFieldMap(Set<String> ingestTypeFilter) throws TableNotFoundException {
-        
+
+    public Multimap<String, String> getCompositeToFieldMap(Set<String> ingestTypeFilter) throws TableNotFoundException {
+
         return this.allFieldMetadataHelper.getCompositeToFieldMap(ingestTypeFilter);
     }
-    
+
     /**
      * A map of composite name to transition date.
      *
      * @return An unmodifiable Map
      * @throws TableNotFoundException
      */
-    public Map<String,Date> getCompositeTransitionDateMap() throws TableNotFoundException {
+    public Map<String, Date> getCompositeTransitionDateMap() throws TableNotFoundException {
         return this.allFieldMetadataHelper.getCompositeTransitionDateMap();
     }
-    
-    public Map<String,Date> getCompositeTransitionDateMap(Set<String> ingestTypeFilter) throws TableNotFoundException {
+
+    public Map<String, Date> getCompositeTransitionDateMap(Set<String> ingestTypeFilter) throws TableNotFoundException {
         return this.allFieldMetadataHelper.getCompositeTransitionDateMap(ingestTypeFilter);
     }
-    
+
     /**
      * A map of whindex field to creation date.
      *
      * @return An unmodifiable Map
      * @throws TableNotFoundException
      */
-    public Map<String,Date> getWhindexCreationDateMap() throws TableNotFoundException {
+    public Map<String, Date> getWhindexCreationDateMap() throws TableNotFoundException {
         return this.allFieldMetadataHelper.getWhindexCreationDateMap();
     }
-    
-    public Map<String,Date> getWhindexCreationDateMap(Set<String> ingestTypeFilter) throws TableNotFoundException {
+
+    public Map<String, Date> getWhindexCreationDateMap(Set<String> ingestTypeFilter) throws TableNotFoundException {
         return this.allFieldMetadataHelper.getWhindexCreationDateMap(ingestTypeFilter);
     }
-    
+
     /**
      * A map of composite name to field separator.
      *
      * @return An unmodifiable Map
      * @throws TableNotFoundException
      */
-    public Map<String,String> getCompositeFieldSeparatorMap() throws TableNotFoundException {
+    public Map<String, String> getCompositeFieldSeparatorMap() throws TableNotFoundException {
         return this.allFieldMetadataHelper.getCompositeFieldSeparatorMap();
     }
-    
-    public Map<String,String> getCompositeFieldSeparatorMap(Set<String> ingestTypeFilter) throws TableNotFoundException {
+
+    public Map<String, String> getCompositeFieldSeparatorMap(Set<String> ingestTypeFilter) throws TableNotFoundException {
         return this.allFieldMetadataHelper.getCompositeFieldSeparatorMap(ingestTypeFilter);
     }
-    
+
     /**
      * Fetch the set of {@link Type}s that are configured for this <code>fieldName</code> as specified in the table pointed to by the
      * <code>metadataTableName</code> parameter.
      *
-     * @param fieldName
-     *            The name of the field to fetch the {@link Type}s for. If null then all dataTypes are returned.
+     * @param fieldName The name of the field to fetch the {@link Type}s for. If null then all dataTypes are returned.
      * @return
      * @throws InstantiationException
      * @throws IllegalAccessException
@@ -842,7 +843,7 @@ public class MetadataHelper {
     public Set<Type<?>> getDatatypesForField(String fieldName) throws InstantiationException, IllegalAccessException, TableNotFoundException {
         return getDatatypesForField(fieldName, null);
     }
-    
+
     /**
      * @return
      * @throws InstantiationException
@@ -850,10 +851,10 @@ public class MetadataHelper {
      * @throws TableNotFoundException
      */
     public Set<Type<?>> getDatatypesForField(String fieldName, Set<String> ingestTypeFilter)
-                    throws InstantiationException, IllegalAccessException, TableNotFoundException {
-        
+            throws InstantiationException, IllegalAccessException, TableNotFoundException {
+
         Set<Type<?>> dataTypes = new HashSet<>();
-        Multimap<String,Type<?>> mm = this.allFieldMetadataHelper.getFieldsToDatatypes(ingestTypeFilter);
+        Multimap<String, Type<?>> mm = this.allFieldMetadataHelper.getFieldsToDatatypes(ingestTypeFilter);
         if (fieldName == null) {
             dataTypes.addAll(mm.values());
         } else {
@@ -864,23 +865,23 @@ public class MetadataHelper {
         }
         return dataTypes;
     }
-    
+
     public TypeMetadata getTypeMetadata() throws TableNotFoundException {
         return this.allFieldMetadataHelper.getTypeMetadata(null);
     }
-    
+
     public TypeMetadata getTypeMetadata(Set<String> ingestTypeFilter) throws TableNotFoundException {
         return this.allFieldMetadataHelper.getTypeMetadata(ingestTypeFilter);
     }
-    
+
     public CompositeMetadata getCompositeMetadata() throws TableNotFoundException {
         return this.allFieldMetadataHelper.getCompositeMetadata(null);
     }
-    
+
     public CompositeMetadata getCompositeMetadata(Set<String> ingestTypeFilter) throws TableNotFoundException {
         return this.allFieldMetadataHelper.getCompositeMetadata(ingestTypeFilter);
     }
-    
+
     /**
      * Fetch the Set of all fields marked as containing term frequency information, {@link ColumnFamilyConstants#COLF_TF}.
      *
@@ -889,18 +890,18 @@ public class MetadataHelper {
      * @throws ExecutionException
      */
     @Cacheable(value = "getEdges", key = "{#root.target.fullUserAuths,#root.target.metadataTableName}")
-    public SetMultimap<Key,Value> getEdges() throws TableNotFoundException, ExecutionException {
+    public SetMultimap<Key, Value> getEdges() throws TableNotFoundException, ExecutionException {
         log.debug("cache fault for getEdges(" + this.auths + ")");
-        SetMultimap<Key,Value> edges = HashMultimap.create();
+        SetMultimap<Key, Value> edges = HashMultimap.create();
         if (log.isTraceEnabled())
             log.trace("getEdges from table: " + metadataTableName);
         // unlike other entries, the edges colf entries have many auths set. We'll use the fullUserAuths in the scanner instead
         // of the minimal set in this.auths
         Scanner scanner = ScannerHelper.createScanner(connector, metadataTableName, fullUserAuths);
-        
+
         scanner.setRange(new Range());
         scanner.fetchColumnFamily(ColumnFamilyConstants.COLF_EDGE);
-        
+
         // First iterator strips the optional attribute2 and attribute3 off the cq, second one
         // combines the protocol buffer data.
         IteratorSetting stripConfig = new IteratorSetting(50, EdgeMetadataCQStrippingIterator.class);
@@ -908,30 +909,29 @@ public class MetadataHelper {
         combineConfig.addOption("columns", ColumnFamilyConstants.COLF_EDGE.toString());
         scanner.addScanIterator(stripConfig);
         scanner.addScanIterator(combineConfig);
-        
-        for (Map.Entry<Key,Value> entry : scanner) {
+
+        for (Map.Entry<Key, Value> entry : scanner) {
             edges.put(entry.getKey(), entry.getValue());
         }
-        
+
         return Multimaps.unmodifiableSetMultimap(edges);
     }
-    
+
     /**
      * Fetch the set of {@link Type}s that are configured for this <code>fieldName</code> as specified in the table pointed to by the
      * <code>metadataTableName</code> parameter.
      *
-     * @param ingestTypeFilter
-     *            Any projection of datatypes to limit the fetch for.
+     * @param ingestTypeFilter Any projection of datatypes to limit the fetch for.
      * @return
      * @throws InstantiationException
      * @throws IllegalAccessException
      * @throws TableNotFoundException
      */
-    public Multimap<String,Type<?>> getFieldsToDatatypes(Set<String> ingestTypeFilter)
-                    throws InstantiationException, IllegalAccessException, TableNotFoundException {
+    public Multimap<String, Type<?>> getFieldsToDatatypes(Set<String> ingestTypeFilter)
+            throws InstantiationException, IllegalAccessException, TableNotFoundException {
         return this.allFieldMetadataHelper.getFieldsToDatatypes(ingestTypeFilter);
     }
-    
+
     /**
      * Scans the metadata table and returns the set of fields that use the supplied normalizer.
      *
@@ -942,10 +942,10 @@ public class MetadataHelper {
      * @throws TableNotFoundException
      */
     public Set<String> getFieldsForDatatype(Class<? extends Type<?>> datawaveType)
-                    throws InstantiationException, IllegalAccessException, TableNotFoundException {
+            throws InstantiationException, IllegalAccessException, TableNotFoundException {
         return getFieldsForDatatype(datawaveType, null);
     }
-    
+
     /**
      * Scans the metadata table and returns the set of fields that use the supplied normalizer.
      * <p>
@@ -960,12 +960,11 @@ public class MetadataHelper {
     public Set<String> getFieldsForDatatype(Class<? extends Type<?>> datawaveType, Set<String> ingestTypeFilter) throws TableNotFoundException {
         return this.allFieldMetadataHelper.getFieldsForDatatype(datawaveType, ingestTypeFilter);
     }
-    
+
     /**
      * Pull an instance of the provided normalizer class name from the internal cache.
      *
-     * @param datatypeClass
-     *            The name of the normalizer class to instantiate.
+     * @param datatypeClass The name of the normalizer class to instantiate.
      * @return An instanace of the normalizer class that was requested.
      * @throws InstantiationException
      * @throws IllegalAccessException
@@ -973,7 +972,7 @@ public class MetadataHelper {
     public Type<?> getDatatypeFromClass(Class<? extends Type<?>> datatypeClass) throws InstantiationException, IllegalAccessException {
         return this.allFieldMetadataHelper.getDatatypeFromClass(datatypeClass);
     }
-    
+
     /**
      * Fetch the Set of all fields marked as containing term frequency information, {@link ColumnFamilyConstants#COLF_TF}.
      *
@@ -982,11 +981,11 @@ public class MetadataHelper {
      */
     @Cacheable(value = "getTermFrequencyFields", key = "{#root.target.auths,#root.target.metadataTableName,#p0}", cacheManager = "metadataHelperCacheManager")
     public Set<String> getTermFrequencyFields(Set<String> ingestTypeFilter) throws TableNotFoundException {
-        Multimap<String,String> termFrequencyFields = loadTermFrequencyFields();
-        
+        Multimap<String, String> termFrequencyFields = loadTermFrequencyFields();
+
         return getFields(termFrequencyFields, ingestTypeFilter);
     }
-    
+
     /**
      * Get index fields using the data type filter.
      *
@@ -995,11 +994,11 @@ public class MetadataHelper {
      * @throws TableNotFoundException
      */
     public Set<String> getIndexedFields(Set<String> ingestTypeFilter) throws TableNotFoundException {
-        Multimap<String,String> indexedFields = this.allFieldMetadataHelper.loadIndexedFields();
-        
+        Multimap<String, String> indexedFields = this.allFieldMetadataHelper.loadIndexedFields();
+
         return getFields(indexedFields, ingestTypeFilter);
     }
-    
+
     /**
      * Get reverse index fields using the data type filter.
      *
@@ -1008,11 +1007,11 @@ public class MetadataHelper {
      * @throws TableNotFoundException
      */
     public Set<String> getReverseIndexedFields(Set<String> ingestTypeFilter) throws TableNotFoundException {
-        Multimap<String,String> reverseIndexedFields = this.allFieldMetadataHelper.loadReverseIndexedFields();
-        
+        Multimap<String, String> reverseIndexedFields = this.allFieldMetadataHelper.loadReverseIndexedFields();
+
         return getFields(reverseIndexedFields, ingestTypeFilter);
     }
-    
+
     /**
      * Get expansion fields using the data type filter.
      *
@@ -1021,11 +1020,11 @@ public class MetadataHelper {
      * @throws TableNotFoundException
      */
     public Set<String> getExpansionFields(Set<String> ingestTypeFilter) throws TableNotFoundException {
-        Multimap<String,String> expansionFields = this.allFieldMetadataHelper.loadExpansionFields();
-        
+        Multimap<String, String> expansionFields = this.allFieldMetadataHelper.loadExpansionFields();
+
         return getFields(expansionFields, ingestTypeFilter);
     }
-    
+
     /**
      * Get the content fields which are those to be queried when using the content functions.
      *
@@ -1034,12 +1033,12 @@ public class MetadataHelper {
      * @throws TableNotFoundException
      */
     public Set<String> getContentFields(Set<String> ingestTypeFilter) throws TableNotFoundException {
-        Multimap<String,String> contentFields = this.allFieldMetadataHelper.loadContentFields();
-        
+        Multimap<String, String> contentFields = this.allFieldMetadataHelper.loadContentFields();
+
         return getFields(contentFields, ingestTypeFilter);
     }
-    
-    private Set<String> getFields(Multimap<String,String> fields, Set<String> ingestTypeFilter) {
+
+    private Set<String> getFields(Multimap<String, String> fields, Set<String> ingestTypeFilter) {
         Set<String> returnedFields = new HashSet<>();
         if (ingestTypeFilter == null) {
             returnedFields.addAll(fields.values());
@@ -1050,7 +1049,7 @@ public class MetadataHelper {
         } // non-null but empty typeFilters allow nothing
         return Collections.unmodifiableSet(returnedFields);
     }
-    
+
     /**
      * Sum all of the frequency counts for a field between a start and end date (inclusive)
      *
@@ -1063,7 +1062,7 @@ public class MetadataHelper {
     public long getCardinalityForField(String fieldName, Date begin, Date end) throws TableNotFoundException {
         return getCardinalityForField(fieldName, null, begin, end);
     }
-    
+
     /**
      * Sum all of the frequency counts for a field in a datatype between a start and end date (inclusive)
      *
@@ -1077,20 +1076,20 @@ public class MetadataHelper {
     public long getCardinalityForField(String fieldName, String datatype, Date begin, Date end) throws TableNotFoundException {
         log.trace("getCardinalityForField from table: " + metadataTableName);
         Text row = new Text(fieldName.toUpperCase());
-        
+
         // Get all the rows in DatawaveMetadata for the field, only in the 'f'
         // colfam
         Scanner bs = ScannerHelper.createScanner(connector, metadataTableName, auths);
-        
+
         Key startKey = new Key(row);
         bs.setRange(new Range(startKey, startKey.followingKey(PartialKey.ROW)));
         bs.fetchColumnFamily(ColumnFamilyConstants.COLF_F);
-        
+
         long count = 0;
-        
-        for (Entry<Key,Value> entry : bs) {
+
+        for (Entry<Key, Value> entry : bs) {
             Text colq = entry.getKey().getColumnQualifier();
-            
+
             int index = colq.find(NULL_BYTE);
             if (index != -1) {
                 // If we were given a non-null datatype
@@ -1106,7 +1105,7 @@ public class MetadataHelper {
                         continue;
                     }
                 }
-                
+
                 // Parse the date to ensure that we want this record
                 String dateStr = "null";
                 Date date;
@@ -1127,35 +1126,35 @@ public class MetadataHelper {
                 }
             }
         }
-        
+
         bs.close();
-        
+
         return count;
     }
-    
+
     public Set<String> getDatatypes(Set<String> ingestTypeFilter) throws TableNotFoundException {
-        
+
         Set<String> datatypes = this.allFieldMetadataHelper.loadDatatypes();
         if (ingestTypeFilter != null && !ingestTypeFilter.isEmpty()) {
             datatypes = Sets.newHashSet(Sets.intersection(datatypes, ingestTypeFilter));
         }
-        
+
         return Collections.unmodifiableSet(datatypes);
     }
-    
+
     public Long getCountsByFieldForDays(String fieldName, Date begin, Date end) {
         return getCountsByFieldForDays(fieldName, begin, end, UniversalSet.instance());
     }
-    
+
     public Long getCountsByFieldForDays(String fieldName, Date begin, Date end, Set<String> ingestTypeFilter) {
         Preconditions.checkNotNull(fieldName);
         Preconditions.checkNotNull(begin);
         Preconditions.checkNotNull(end);
         Preconditions.checkArgument(begin.before(end));
-        
+
         Date truncatedBegin = DateUtils.truncate(begin, Calendar.DATE);
         Date truncatedEnd = DateUtils.truncate(end, Calendar.DATE);
-        
+
         if (truncatedEnd.getTime() != end.getTime()) {
             // If we don't have the same time for both, we actually truncated
             // the end,
@@ -1163,22 +1162,22 @@ public class MetadataHelper {
             // end
             truncatedEnd = new Date(truncatedEnd.getTime() + 86400000);
         }
-        
+
         Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
         cal.setTime(truncatedBegin);
-        
+
         long sum = 0l;
         while (cal.getTime().before(truncatedEnd)) {
             Date curDate = cal.getTime();
             String desiredDate = DateHelper.format(curDate);
-            
+
             sum += getCountsByFieldInDayWithTypes(fieldName, desiredDate, ingestTypeFilter);
             cal.add(Calendar.DATE, 1);
         }
-        
+
         return sum;
     }
-    
+
     /**
      * Return the sum across all datatypes of the {@link ColumnFamilyConstants#COLF_F} on the given day.
      *
@@ -1189,7 +1188,7 @@ public class MetadataHelper {
     public Long getCountsByFieldInDay(String fieldName, String date) {
         return getCountsByFieldInDayWithTypes(fieldName, date, UniversalSet.instance());
     }
-    
+
     /**
      * Return the sum across all datatypes of the {@link ColumnFamilyConstants#COLF_F} on the given day in the provided types
      *
@@ -1201,77 +1200,77 @@ public class MetadataHelper {
     public Long getCountsByFieldInDayWithTypes(String fieldName, String date, final Set<String> datatypes) {
         Preconditions.checkNotNull(fieldName);
         Preconditions.checkNotNull(date);
-        
+
         try {
-            Map<String,Long> countsByType = getCountsByFieldInDayWithTypes(Maps.immutableEntry(fieldName, date));
-            
-            Iterable<Entry<String,Long>> filteredByType = datatypes == null ? countsByType.entrySet()
-                            : Iterables.filter(countsByType.entrySet(), input -> datatypes.contains(input.getKey()));
-            
+            Map<String, Long> countsByType = getCountsByFieldInDayWithTypes(Maps.immutableEntry(fieldName, date));
+
+            Iterable<Entry<String, Long>> filteredByType = datatypes == null ? countsByType.entrySet()
+                    : Iterables.filter(countsByType.entrySet(), input -> datatypes.contains(input.getKey()));
+
             long sum = 0;
-            for (Entry<String,Long> entry : filteredByType) {
+            for (Entry<String, Long> entry : filteredByType) {
                 sum += entry.getValue();
             }
-            
+
             return sum;
         } catch (TableNotFoundException | IOException e) {
             throw new RuntimeException(e);
         }
     }
-    
-    protected HashMap<String,Long> getCountsByFieldInDayWithTypes(Entry<String,String> identifier) throws TableNotFoundException, IOException {
+
+    protected HashMap<String, Long> getCountsByFieldInDayWithTypes(Entry<String, String> identifier) throws TableNotFoundException, IOException {
         String fieldName = identifier.getKey();
         String date = identifier.getValue();
-        
+
         // try to get the counts by field using the original (cached) connector
-        HashMap<String,Long> datatypeToCounts = getCountsByFieldInDayWithTypes(fieldName, date, connector, null);
-        
+        HashMap<String, Long> datatypeToCounts = getCountsByFieldInDayWithTypes(fieldName, date, connector, null);
+
         // if we don't get a hit, try the real connector
         if (datatypeToCounts.isEmpty() && connector instanceof WrappedConnector) {
             WrappedConnector wrappedConnector = ((WrappedConnector) connector);
             datatypeToCounts = getCountsByFieldInDayWithTypes(fieldName, date, wrappedConnector.getReal(), wrappedConnector);
         }
-        
+
         return datatypeToCounts;
     }
-    
-    protected HashMap<String,Long> getCountsByFieldInDayWithTypes(String fieldName, String date, Connector connector, WrappedConnector wrappedConnector)
-                    throws TableNotFoundException, IOException {
-        final HashMap<String,Long> datatypeToCounts = Maps.newHashMap();
-        
+
+    protected HashMap<String, Long> getCountsByFieldInDayWithTypes(String fieldName, String date, Connector connector, WrappedConnector wrappedConnector)
+            throws TableNotFoundException, IOException {
+        final HashMap<String, Long> datatypeToCounts = Maps.newHashMap();
+
         BatchWriter writer = null;
-        
+
         try {
             // we have to use the real connector since the f column is not cached
             Scanner scanner = ScannerHelper.createScanner(connector, metadataTableName, auths);
             scanner.fetchColumnFamily(ColumnFamilyConstants.COLF_F);
             scanner.setRange(Range.exact(fieldName));
-            
+
             IteratorSetting cqRegex = new IteratorSetting(50, RegExFilter.class);
             RegExFilter.setRegexs(cqRegex, null, null, ".*\u0000" + date, null, false);
             scanner.addScanIterator(cqRegex);
-            
+
             final Text holder = new Text();
-            for (Entry<Key,Value> entry : scanner) {
+            for (Entry<Key, Value> entry : scanner) {
                 // if this is the real connector, and wrapped connector is not null, it means
                 // that we didn't get a hit in the cache. So, we will update the cache with the
                 // entries from the real table
                 if (wrappedConnector != null && connector == wrappedConnector.getReal()) {
                     writer = updateCache(entry, writer, wrappedConnector);
                 }
-                
+
                 ByteArrayInputStream bais = new ByteArrayInputStream(entry.getValue().get());
                 DataInputStream inputStream = new DataInputStream(bais);
-                
+
                 Long sum = WritableUtils.readVLong(inputStream);
-                
+
                 entry.getKey().getColumnQualifier(holder);
                 int offset = holder.find(NULL_BYTE);
-                
+
                 Preconditions.checkArgument(-1 != offset, "Could not find nullbyte separator in column qualifier for: " + entry.getKey());
-                
+
                 String datatype = Text.decode(holder.getBytes(), 0, offset);
-                
+
                 datatypeToCounts.put(datatype, sum);
             }
         } finally {
@@ -1283,56 +1282,56 @@ public class MetadataHelper {
                 }
             }
         }
-        
+
         return datatypeToCounts;
     }
-    
+
     public Date getEarliestOccurrenceOfField(String fieldName) {
         return getEarliestOccurrenceOfFieldWithType(fieldName, null);
     }
-    
+
     public Date getEarliestOccurrenceOfFieldWithType(String fieldName, final String dataType) {
         // try to get the date using the original (cached) connector
         Date date = getEarliestOccurrenceOfFieldWithType(fieldName, dataType, connector, null);
-        
+
         // if we don't get a hit, try the real connector
         if (date == null && connector instanceof WrappedConnector) {
             WrappedConnector wrappedConnector = ((WrappedConnector) connector);
             date = getEarliestOccurrenceOfFieldWithType(fieldName, dataType, wrappedConnector.getReal(), wrappedConnector);
         }
-        
+
         return date;
     }
-    
+
     protected Date getEarliestOccurrenceOfFieldWithType(String fieldName, final String dataType, Connector connector, WrappedConnector wrappedConnector) {
         String dateString = null;
         BatchWriter writer = null;
-        
+
         try {
             Scanner scanner = ScannerHelper.createScanner(connector, metadataTableName, auths);
             scanner.fetchColumnFamily(ColumnFamilyConstants.COLF_F);
             scanner.setRange(Range.exact(fieldName));
-            
+
             // if a type was specified, add a regex filter for it
             if (dataType != null) {
                 IteratorSetting cqRegex = new IteratorSetting(50, RegExFilter.class);
                 RegExFilter.setRegexs(cqRegex, null, null, dataType + "\u0000.*", null, false);
                 scanner.addScanIterator(cqRegex);
             }
-            
+
             try {
                 final Text holder = new Text();
-                for (Entry<Key,Value> entry : scanner) {
+                for (Entry<Key, Value> entry : scanner) {
                     // if this is the real connector, and wrapped connector is not null, it means
                     // that we didn't get a hit in the cache. So, we will update the cache with the
                     // entries from the real table
                     if (wrappedConnector != null && connector == wrappedConnector.getReal()) {
                         writer = updateCache(entry, writer, wrappedConnector);
                     }
-                    
+
                     entry.getKey().getColumnQualifier(holder);
                     int startPos = holder.find(NULL_BYTE) + 1;
-                    
+
                     if (0 == startPos) {
                         log.trace("Could not find nullbyte separator in column qualifier for: " + entry.getKey());
                     } else if ((holder.getLength() - startPos) <= 0) {
@@ -1360,47 +1359,44 @@ public class MetadataHelper {
                 }
             }
         }
-        
+
         Date date = null;
         if (dateString != null) {
             date = DateHelper.parse(dateString);
         }
-        
+
         return date;
     }
-    
+
     /**
      * Updates the table cache via the mock connector with the given entry and writer. If writer is null, a writer will be created and returned for subsequent
      * use.
      *
-     * @param entry
-     *            the entry to add
-     * @param writer
-     *            the batch writer
-     * @param wrappedConnector
-     *            the wrapped connector
+     * @param entry            the entry to add
+     * @param writer           the batch writer
+     * @param wrappedConnector the wrapped connector
      * @return a batch writer
      */
-    private BatchWriter updateCache(Entry<Key,Value> entry, BatchWriter writer, WrappedConnector wrappedConnector) {
+    private BatchWriter updateCache(Entry<Key, Value> entry, BatchWriter writer, WrappedConnector wrappedConnector) {
         try {
             if (writer == null) {
                 writer = wrappedConnector.getMock().createBatchWriter(metadataTableName, 10L * (1024L * 1024L), 100L, 1);
             }
-            
+
             Key valueKey = entry.getKey();
-            
+
             Mutation m = new Mutation(entry.getKey().getRow());
             m.put(valueKey.getColumnFamily(), valueKey.getColumnQualifier(), new ColumnVisibility(valueKey.getColumnVisibility()), valueKey.getTimestamp(),
-                            entry.getValue());
-            
+                    entry.getValue());
+
             writer.addMutation(m);
         } catch (MutationsRejectedException | TableNotFoundException e) {
             log.trace("Unable to add entry to cache for: " + entry.getKey());
         }
-        
+
         return writer;
     }
-    
+
     /**
      * Transform an Iterable of MetadataEntry's to just fieldName. This does not de-duplicate field names
      *
@@ -1410,7 +1406,7 @@ public class MetadataHelper {
     public static Iterable<String> fieldNames(Iterable<MetadataEntry> from) {
         return Iterables.transform(from, toFieldName);
     }
-    
+
     /**
      * Transform an Iterable of MetadataEntry's to just fieldName, removing duplicates.
      *
@@ -1420,7 +1416,7 @@ public class MetadataHelper {
     public static Set<String> uniqueFieldNames(Iterable<MetadataEntry> from) {
         return Sets.newHashSet(fieldNames(from));
     }
-    
+
     /**
      * Transform an Iterable of MetadataEntry's to just datatype. This does not de-duplicate datatypes
      *
@@ -1430,7 +1426,7 @@ public class MetadataHelper {
     public static Iterable<String> datatypes(Iterable<MetadataEntry> from) {
         return Iterables.transform(from, toDatatype);
     }
-    
+
     /**
      * Transform an Iterable of MetadataEntry's to just datatype, removing duplicates.
      *
@@ -1440,22 +1436,22 @@ public class MetadataHelper {
     public static Set<String> uniqueDatatypes(Iterable<MetadataEntry> from) {
         return Sets.newHashSet(datatypes(from));
     }
-    
+
     /**
      * Fetches the first entry from each row in the table. This equates to the set of all fields that have occurred in the database. Returns a multimap of
      * datatype to field
      *
      * @throws TableNotFoundException
      */
-    protected Multimap<String,String> loadAllFields() throws TableNotFoundException {
-        Multimap<String,String> fields = HashMultimap.create();
-        
+    protected Multimap<String, String> loadAllFields() throws TableNotFoundException {
+        Multimap<String, String> fields = HashMultimap.create();
+
         Scanner bs = ScannerHelper.createScanner(connector, metadataTableName, auths);
         if (log.isTraceEnabled())
             log.trace("loadAllFields from table: " + metadataTableName);
-        
+
         bs.setRange(new Range());
-        
+
         // We don't want to fetch all columns because that could include model
         // field names
         bs.fetchColumnFamily(ColumnFamilyConstants.COLF_T);
@@ -1464,32 +1460,32 @@ public class MetadataHelper {
         bs.fetchColumnFamily(ColumnFamilyConstants.COLF_RI);
         bs.fetchColumnFamily(ColumnFamilyConstants.COLF_TF);
         bs.fetchColumnFamily(ColumnFamilyConstants.COLF_CI);
-        
-        Iterator<Entry<Key,Value>> iterator = bs.iterator();
-        
+
+        Iterator<Entry<Key, Value>> iterator = bs.iterator();
+
         while (iterator.hasNext()) {
-            Entry<Key,Value> entry = iterator.next();
+            Entry<Key, Value> entry = iterator.next();
             Key k = entry.getKey();
-            
+
             String fieldname = k.getRow().toString();
             String datatype = getDatatype(k);
-            
+
             fields.put(datatype, fieldname);
         }
-        
+
         return Multimaps.unmodifiableMultimap(fields);
     }
-    
+
     /**
      * Fetches results from metadata table and calculates the set of fieldNames which are indexed but do not appear as an attribute on the Event Returns a
      * multimap of datatype to field
      *
      * @throws TableNotFoundException
      */
-    protected Multimap<String,String> loadIndexOnlyFields() throws TableNotFoundException {
+    protected Multimap<String, String> loadIndexOnlyFields() throws TableNotFoundException {
         return this.allFieldMetadataHelper.getIndexOnlyFields();
     }
-    
+
     /**
      * Fetch the Set of all fields marked as containing term frequency information, {@link ColumnFamilyConstants#COLF_TF}. Returns a multimap of datatype to
      * field
@@ -1497,57 +1493,57 @@ public class MetadataHelper {
      * @return
      * @throws TableNotFoundException
      */
-    protected Multimap<String,String> loadTermFrequencyFields() throws TableNotFoundException {
-        Multimap<String,String> fields = HashMultimap.create();
+    protected Multimap<String, String> loadTermFrequencyFields() throws TableNotFoundException {
+        Multimap<String, String> fields = HashMultimap.create();
         if (log.isTraceEnabled())
             log.trace("loadTermFrequencyFields from table: " + metadataTableName);
         // Scanner to the provided metadata table
         Scanner bs = ScannerHelper.createScanner(connector, metadataTableName, auths);
-        
+
         bs.setRange(new Range());
         bs.fetchColumnFamily(ColumnFamilyConstants.COLF_TF);
-        
-        for (Entry<Key,Value> entry : bs) {
+
+        for (Entry<Key, Value> entry : bs) {
             fields.put(getDatatype(entry.getKey()), entry.getKey().getRow().toString());
         }
-        
+
         return Multimaps.unmodifiableMultimap(fields);
     }
-    
+
     private static String getKey(Instance instance, String metadataTableName) {
         StringBuilder builder = new StringBuilder();
         builder.append(instance != null ? instance.getInstanceID() : null).append('\0');
         builder.append(metadataTableName).append('\0');
         return builder.toString();
     }
-    
+
     private static String getKey(MetadataHelper helper) {
         return getKey(helper.instance, helper.metadataTableName);
     }
-    
+
     @Override
     public String toString() {
         return getKey(this);
     }
-    
+
     public static void basicIterator(Connector connector, String tableName, Collection<Authorizations> auths)
-                    throws TableNotFoundException, InvalidProtocolBufferException {
+            throws TableNotFoundException, InvalidProtocolBufferException {
         if (log.isTraceEnabled())
             log.trace("--- basicIterator ---" + tableName);
         Scanner scanner = connector.createScanner(tableName, auths.iterator().next());
         Range range = new Range();
         scanner.setRange(range);
-        Iterator<Entry<Key,Value>> iter = scanner.iterator();
+        Iterator<Entry<Key, Value>> iter = scanner.iterator();
         while (iter.hasNext()) {
-            Entry<Key,Value> entry = iter.next();
+            Entry<Key, Value> entry = iter.next();
             Key k = entry.getKey();
             if (log.isTraceEnabled())
                 log.trace("Key: " + k);
         }
     }
-    
+
     public String getMetadataTableName() {
         return metadataTableName;
     }
-    
+
 }

--- a/src/test/java/datawave/query/util/MetadataHelperTest.java
+++ b/src/test/java/datawave/query/util/MetadataHelperTest.java
@@ -12,7 +12,6 @@ import org.apache.accumulo.core.client.BatchWriterConfig;
 import org.apache.accumulo.core.client.MutationsRejectedException;
 import org.apache.accumulo.core.client.TableExistsException;
 import org.apache.accumulo.core.client.TableNotFoundException;
-import org.apache.accumulo.core.client.admin.TableOperations;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.security.Authorizations;
@@ -29,8 +28,9 @@ public class MetadataHelperTest {
     private static final String TABLE_METADATA = "testMetadataTable";
     private static final String[] AUTHS = {"FOO"};
     private static MetadataHelper mdh;
+    private static AccumuloClient accumuloClient;
     
-    private static AllFieldMetadataHelper createAllFieldMetadataHelper(AccumuloClient accumuloClient) {
+    private static AllFieldMetadataHelper createAllFieldMetadataHelper() {
         final Set<Authorizations> allMetadataAuths = Collections.emptySet();
         final Set<Authorizations> auths = Collections.singleton(new Authorizations(AUTHS));
         TypeMetadataHelper tmh = new TypeMetadataHelper(Maps.newHashMap(), allMetadataAuths, accumuloClient, TABLE_METADATA, auths, false);
@@ -39,19 +39,10 @@ public class MetadataHelperTest {
         return new AllFieldMetadataHelper(tmh, cmh, accumuloClient, TABLE_METADATA, auths, allMetadataAuths);
     }
     
-    private static void setupTable(AccumuloClient accumuloClient) throws AccumuloException, TableExistsException, AccumuloSecurityException {
-        TableOperations tableOperations = accumuloClient.tableOperations();
-        if (!tableOperations.exists(TABLE_METADATA)) {
-            tableOperations.create(TABLE_METADATA);
-        }
-    }
-    
-    private static void addFields(AccumuloClient accumuloClient) throws TableNotFoundException {
+    private static void addFields(Mutation m) throws TableNotFoundException {
         BatchWriterConfig config = new BatchWriterConfig();
         config.setMaxMemory(0);
         try (BatchWriter writer = accumuloClient.createBatchWriter(TABLE_METADATA, config)) {
-            Mutation m = new Mutation("rowA");
-            m.put("t", "dataTypeA", new Value("value"));
             writer.addMutation(m);
             writer.flush();
         } catch (MutationsRejectedException e) {
@@ -61,25 +52,26 @@ public class MetadataHelperTest {
     
     @Before
     public void setup() throws TableNotFoundException, AccumuloException, TableExistsException, AccumuloSecurityException {
-        AccumuloClient accumuloClient = new InMemoryAccumuloClient("root", new InMemoryInstance(MetadataHelperTest.class.toString()));
-        setupTable(accumuloClient);
-        addFields(accumuloClient);
-        mdh = new MetadataHelper(createAllFieldMetadataHelper(accumuloClient), Collections.emptySet(), accumuloClient, TABLE_METADATA, Collections.emptySet(),
+        accumuloClient = new InMemoryAccumuloClient("root", new InMemoryInstance(MetadataHelperTest.class.toString()));
+        if (!accumuloClient.tableOperations().exists(TABLE_METADATA)) {
+            accumuloClient.tableOperations().create(TABLE_METADATA);
+        }
+        mdh = new MetadataHelper(createAllFieldMetadataHelper(), Collections.emptySet(), accumuloClient, TABLE_METADATA, Collections.emptySet(),
                         Collections.emptySet());
     }
     
     @Test // we expect our row to be filtered out
-    public void testPopulatedTypeFilter() throws TableNotFoundException {
-        assertEquals(Collections.EMPTY_SET, mdh.getAllFields(Collections.singleton("rowA")));
+    public void testSingleFieldFilter() throws TableNotFoundException {
+        Mutation m = new Mutation("rowA");
+        m.put("t", "dataTypeA", new Value("value"));
+        addFields(m);
+        
+        testFilter(Collections.EMPTY_SET, mdh.getAllFields(Collections.singleton("rowA")));
+        testFilter(Collections.singleton("rowA"), mdh.getAllFields(null));
+        testFilter(Collections.EMPTY_SET, mdh.getAllFields(Collections.EMPTY_SET));
     }
     
-    @Test // we expect a null filter to allow all the things
-    public void testNullTypeFilter() throws TableNotFoundException {
-        assertEquals(Collections.singleton("rowA"), mdh.getAllFields(null));
-    }
-    
-    @Test // we expect an empty filter to allow none of the things
-    public void testEmptyTypeFilter() throws TableNotFoundException {
-        assertEquals(Collections.EMPTY_SET, mdh.getAllFields(Collections.EMPTY_SET));
+    private void testFilter(Set<String> expected, Set<String> actual) throws TableNotFoundException {
+        assertEquals(expected, actual);
     }
 }

--- a/src/test/java/datawave/query/util/MetadataHelperTest.java
+++ b/src/test/java/datawave/query/util/MetadataHelperTest.java
@@ -25,27 +25,27 @@ import java.util.Set;
 import static org.junit.Assert.assertEquals;
 
 public class MetadataHelperTest {
-
+    
     private static final String TABLE_METADATA = "testMetadataTable";
     private static final String[] AUTHS = {"FOO"};
     private static MetadataHelper mdh;
-
+    
     private static AllFieldMetadataHelper createAllFieldMetadataHelper(AccumuloClient accumuloClient) {
         final Set<Authorizations> allMetadataAuths = Collections.emptySet();
         final Set<Authorizations> auths = Collections.singleton(new Authorizations(AUTHS));
         TypeMetadataHelper tmh = new TypeMetadataHelper(Maps.newHashMap(), allMetadataAuths, accumuloClient, TABLE_METADATA, auths, false);
         CompositeMetadataHelper cmh = new CompositeMetadataHelper(accumuloClient, TABLE_METADATA, auths);
-
+        
         return new AllFieldMetadataHelper(tmh, cmh, accumuloClient, TABLE_METADATA, auths, allMetadataAuths);
     }
-
+    
     private static void setupTable(AccumuloClient accumuloClient) throws AccumuloException, TableExistsException, AccumuloSecurityException {
         TableOperations tableOperations = accumuloClient.tableOperations();
         if (!tableOperations.exists(TABLE_METADATA)) {
             tableOperations.create(TABLE_METADATA);
         }
     }
-
+    
     private static void addFields(AccumuloClient accumuloClient) throws TableNotFoundException {
         BatchWriterConfig config = new BatchWriterConfig();
         config.setMaxMemory(0);
@@ -58,25 +58,26 @@ public class MetadataHelperTest {
             throw new RuntimeException(e);
         }
     }
-
+    
     @Before
     public void setup() throws TableNotFoundException, AccumuloException, TableExistsException, AccumuloSecurityException {
         AccumuloClient accumuloClient = new InMemoryAccumuloClient("root", new InMemoryInstance(MetadataHelperTest.class.toString()));
         setupTable(accumuloClient);
         addFields(accumuloClient);
-        mdh = new MetadataHelper(createAllFieldMetadataHelper(accumuloClient), Collections.emptySet(), accumuloClient, TABLE_METADATA, Collections.emptySet(), Collections.emptySet());
+        mdh = new MetadataHelper(createAllFieldMetadataHelper(accumuloClient), Collections.emptySet(), accumuloClient, TABLE_METADATA, Collections.emptySet(),
+                        Collections.emptySet());
     }
-
+    
     @Test // we expect our row to be filtered out
     public void testPopulatedTypeFilter() throws TableNotFoundException {
         assertEquals(Collections.EMPTY_SET, mdh.getAllFields(Collections.singleton("rowA")));
     }
-
+    
     @Test // we expect a null filter to allow all the things
     public void testNullTypeFilter() throws TableNotFoundException {
         assertEquals(Collections.singleton("rowA"), mdh.getAllFields(null));
     }
-
+    
     @Test // we expect an empty filter to allow none of the things
     public void testEmptyTypeFilter() throws TableNotFoundException {
         assertEquals(Collections.EMPTY_SET, mdh.getAllFields(Collections.EMPTY_SET));

--- a/src/test/java/datawave/query/util/MetadataHelperTest.java
+++ b/src/test/java/datawave/query/util/MetadataHelperTest.java
@@ -1,18 +1,18 @@
 package datawave.query.util;
 
 import com.google.common.collect.Maps;
+import datawave.accumulo.inmemory.InMemoryAccumuloClient;
 import datawave.accumulo.inmemory.InMemoryInstance;
 import datawave.query.composite.CompositeMetadataHelper;
+import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.BatchWriterConfig;
-import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.MutationsRejectedException;
 import org.apache.accumulo.core.client.TableExistsException;
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.client.admin.TableOperations;
-import org.apache.accumulo.core.client.security.tokens.PasswordToken;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.security.Authorizations;
@@ -25,40 +25,31 @@ import java.util.Set;
 import static org.junit.Assert.assertEquals;
 
 public class MetadataHelperTest {
-    
+
     private static final String TABLE_METADATA = "testMetadataTable";
     private static final String[] AUTHS = {"FOO"};
-    private static final InMemoryInstance instance = new InMemoryInstance();
     private static MetadataHelper mdh;
-    
-    private static AllFieldMetadataHelper createAllFieldMetadataHelper(Connector connector) {
+
+    private static AllFieldMetadataHelper createAllFieldMetadataHelper(AccumuloClient accumuloClient) {
         final Set<Authorizations> allMetadataAuths = Collections.emptySet();
         final Set<Authorizations> auths = Collections.singleton(new Authorizations(AUTHS));
-        TypeMetadataHelper tmh = new TypeMetadataHelper(Maps.newHashMap(), allMetadataAuths, connector, TABLE_METADATA, auths, false);
-        CompositeMetadataHelper cmh = new CompositeMetadataHelper(connector, TABLE_METADATA, auths);
-        
-        return new AllFieldMetadataHelper(tmh, cmh, connector, TABLE_METADATA, auths, allMetadataAuths);
+        TypeMetadataHelper tmh = new TypeMetadataHelper(Maps.newHashMap(), allMetadataAuths, accumuloClient, TABLE_METADATA, auths, false);
+        CompositeMetadataHelper cmh = new CompositeMetadataHelper(accumuloClient, TABLE_METADATA, auths);
+
+        return new AllFieldMetadataHelper(tmh, cmh, accumuloClient, TABLE_METADATA, auths, allMetadataAuths);
     }
-    
-    private static Connector getConnector() {
-        try {
-            return instance.getConnector("root", new PasswordToken(""));
-        } catch (AccumuloException | AccumuloSecurityException e) {
-            throw new RuntimeException(e);
-        }
-    }
-    
-    private static void setupTable(Connector connector) throws AccumuloException, TableExistsException, AccumuloSecurityException {
-        TableOperations tableOperations = connector.tableOperations();
+
+    private static void setupTable(AccumuloClient accumuloClient) throws AccumuloException, TableExistsException, AccumuloSecurityException {
+        TableOperations tableOperations = accumuloClient.tableOperations();
         if (!tableOperations.exists(TABLE_METADATA)) {
             tableOperations.create(TABLE_METADATA);
         }
     }
-    
-    private static void addFields(Connector connector) throws TableNotFoundException {
+
+    private static void addFields(AccumuloClient accumuloClient) throws TableNotFoundException {
         BatchWriterConfig config = new BatchWriterConfig();
         config.setMaxMemory(0);
-        try (BatchWriter writer = connector.createBatchWriter(TABLE_METADATA, config)) {
+        try (BatchWriter writer = accumuloClient.createBatchWriter(TABLE_METADATA, config)) {
             Mutation m = new Mutation("rowA");
             m.put("t", "dataTypeA", new Value("value"));
             writer.addMutation(m);
@@ -67,25 +58,25 @@ public class MetadataHelperTest {
             throw new RuntimeException(e);
         }
     }
-    
+
     @Before
     public void setup() throws TableNotFoundException, AccumuloException, TableExistsException, AccumuloSecurityException {
-        setupTable(getConnector());
-        addFields(getConnector());
-        mdh = new MetadataHelper(createAllFieldMetadataHelper(getConnector()), Collections.emptySet(), getConnector(), TABLE_METADATA, Collections.emptySet(),
-                        Collections.emptySet());
+        AccumuloClient accumuloClient = new InMemoryAccumuloClient("root", new InMemoryInstance(MetadataHelperTest.class.toString()));
+        setupTable(accumuloClient);
+        addFields(accumuloClient);
+        mdh = new MetadataHelper(createAllFieldMetadataHelper(accumuloClient), Collections.emptySet(), accumuloClient, TABLE_METADATA, Collections.emptySet(), Collections.emptySet());
     }
-    
+
     @Test // we expect our row to be filtered out
     public void testPopulatedTypeFilter() throws TableNotFoundException {
         assertEquals(Collections.EMPTY_SET, mdh.getAllFields(Collections.singleton("rowA")));
     }
-    
+
     @Test // we expect a null filter to allow all the things
     public void testNullTypeFilter() throws TableNotFoundException {
         assertEquals(Collections.singleton("rowA"), mdh.getAllFields(null));
     }
-    
+
     @Test // we expect an empty filter to allow none of the things
     public void testEmptyTypeFilter() throws TableNotFoundException {
         assertEquals(Collections.EMPTY_SET, mdh.getAllFields(Collections.EMPTY_SET));

--- a/src/test/java/datawave/query/util/MetadataHelperTest.java
+++ b/src/test/java/datawave/query/util/MetadataHelperTest.java
@@ -1,6 +1,7 @@
 package datawave.query.util;
 
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import datawave.accumulo.inmemory.InMemoryAccumuloClient;
 import datawave.accumulo.inmemory.InMemoryInstance;
 import datawave.query.composite.CompositeMetadataHelper;
@@ -27,8 +28,8 @@ public class MetadataHelperTest {
     
     private static final String TABLE_METADATA = "testMetadataTable";
     private static final String[] AUTHS = {"FOO"};
-    private static MetadataHelper mdh;
     private static AccumuloClient accumuloClient;
+    private static MetadataHelper mdh;
     
     private static AllFieldMetadataHelper createAllFieldMetadataHelper() {
         final Set<Authorizations> allMetadataAuths = Collections.emptySet();
@@ -60,14 +61,29 @@ public class MetadataHelperTest {
                         Collections.emptySet());
     }
     
-    @Test // we expect our row to be filtered out
+    @Test
     public void testSingleFieldFilter() throws TableNotFoundException {
         Mutation m = new Mutation("rowA");
         m.put("t", "dataTypeA", new Value("value"));
         addFields(m);
         
-        testFilter(Collections.EMPTY_SET, mdh.getAllFields(Collections.singleton("rowA")));
+        testFilter(Collections.singleton("rowA"), mdh.getAllFields(Collections.singleton("dataTypeA")));
         testFilter(Collections.singleton("rowA"), mdh.getAllFields(null));
+        testFilter(Collections.EMPTY_SET, mdh.getAllFields(Collections.EMPTY_SET));
+    }
+    
+    @Test
+    public void testMultipleFieldFilter() throws TableNotFoundException {
+        Mutation m1 = new Mutation("rowA");
+        m1.put("t", "dataTypeA", new Value("value"));
+        addFields(m1);
+        
+        Mutation m2 = new Mutation("rowB");
+        m2.put("t", "dataTypeB", new Value("value"));
+        addFields(m2);
+        
+        testFilter(Collections.singleton("rowB"), mdh.getAllFields(Collections.singleton("dataTypeB")));
+        testFilter(Sets.newHashSet("rowA", "rowB"), mdh.getAllFields(null));
         testFilter(Collections.EMPTY_SET, mdh.getAllFields(Collections.EMPTY_SET));
     }
     

--- a/src/test/java/datawave/query/util/MetadataHelperTest.java
+++ b/src/test/java/datawave/query/util/MetadataHelperTest.java
@@ -51,6 +51,10 @@ public class MetadataHelperTest {
         }
     }
     
+    private static void clearTable() throws TableNotFoundException, AccumuloException, AccumuloSecurityException {
+        accumuloClient.tableOperations().deleteRows(TABLE_METADATA, null, null);
+    }
+    
     @Before
     public void setup() throws TableNotFoundException, AccumuloException, TableExistsException, AccumuloSecurityException {
         accumuloClient = new InMemoryAccumuloClient("root", new InMemoryInstance(MetadataHelperTest.class.toString()));
@@ -62,7 +66,8 @@ public class MetadataHelperTest {
     }
     
     @Test
-    public void testSingleFieldFilter() throws TableNotFoundException {
+    public void testSingleFieldFilter() throws TableNotFoundException, AccumuloException, AccumuloSecurityException {
+        clearTable();
         Mutation m = new Mutation("rowA");
         m.put("t", "dataTypeA", new Value("value"));
         addFields(m);
@@ -73,7 +78,8 @@ public class MetadataHelperTest {
     }
     
     @Test
-    public void testMultipleFieldFilter() throws TableNotFoundException {
+    public void testMultipleFieldFilter() throws TableNotFoundException, AccumuloException, AccumuloSecurityException {
+        clearTable();
         Mutation m1 = new Mutation("rowA");
         m1.put("t", "dataTypeA", new Value("value"));
         addFields(m1);
@@ -83,6 +89,26 @@ public class MetadataHelperTest {
         addFields(m2);
         
         testFilter(Collections.singleton("rowB"), mdh.getAllFields(Collections.singleton("dataTypeB")));
+        testFilter(Sets.newHashSet("rowA", "rowB"), mdh.getAllFields(null));
+        testFilter(Collections.EMPTY_SET, mdh.getAllFields(Collections.EMPTY_SET));
+    }
+    
+    @Test
+    public void testMultipleFieldFilter2() throws TableNotFoundException, AccumuloException, AccumuloSecurityException {
+        clearTable();
+        Mutation m1 = new Mutation("rowA");
+        m1.put("t", "dataTypeA", new Value("value"));
+        addFields(m1);
+        
+        Mutation m2 = new Mutation("rowA");
+        m2.put("t", "dataTypeB", new Value("value"));
+        addFields(m2);
+        
+        Mutation m3 = new Mutation("rowB");
+        m3.put("t", "dataTypeC", new Value("value"));
+        addFields(m3);
+        
+        testFilter(Collections.singleton("rowA"), mdh.getAllFields(Collections.singleton("dataTypeB")));
         testFilter(Sets.newHashSet("rowA", "rowB"), mdh.getAllFields(null));
         testFilter(Collections.EMPTY_SET, mdh.getAllFields(Collections.EMPTY_SET));
     }

--- a/src/test/java/datawave/query/util/MetadataHelperTest.java
+++ b/src/test/java/datawave/query/util/MetadataHelperTest.java
@@ -1,0 +1,93 @@
+package datawave.query.util;
+
+import com.google.common.collect.Maps;
+import datawave.accumulo.inmemory.InMemoryInstance;
+import datawave.query.composite.CompositeMetadataHelper;
+import org.apache.accumulo.core.client.AccumuloException;
+import org.apache.accumulo.core.client.AccumuloSecurityException;
+import org.apache.accumulo.core.client.BatchWriter;
+import org.apache.accumulo.core.client.BatchWriterConfig;
+import org.apache.accumulo.core.client.Connector;
+import org.apache.accumulo.core.client.MutationsRejectedException;
+import org.apache.accumulo.core.client.TableExistsException;
+import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.client.admin.TableOperations;
+import org.apache.accumulo.core.client.security.tokens.PasswordToken;
+import org.apache.accumulo.core.data.Mutation;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.security.Authorizations;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+
+public class MetadataHelperTest {
+    
+    private static final String TABLE_METADATA = "testMetadataTable";
+    private static final String[] AUTHS = {"FOO"};
+    private static final InMemoryInstance instance = new InMemoryInstance();
+    private static MetadataHelper mdh;
+    
+    private static AllFieldMetadataHelper createAllFieldMetadataHelper(Connector connector) {
+        final Set<Authorizations> allMetadataAuths = Collections.emptySet();
+        final Set<Authorizations> auths = Collections.singleton(new Authorizations(AUTHS));
+        TypeMetadataHelper tmh = new TypeMetadataHelper(Maps.newHashMap(), allMetadataAuths, connector, TABLE_METADATA, auths, false);
+        CompositeMetadataHelper cmh = new CompositeMetadataHelper(connector, TABLE_METADATA, auths);
+        
+        return new AllFieldMetadataHelper(tmh, cmh, connector, TABLE_METADATA, auths, allMetadataAuths);
+    }
+    
+    private static Connector getConnector() {
+        try {
+            return instance.getConnector("root", new PasswordToken(""));
+        } catch (AccumuloException | AccumuloSecurityException e) {
+            throw new RuntimeException(e);
+        }
+    }
+    
+    private static void setupTable(Connector connector) throws AccumuloException, TableExistsException, AccumuloSecurityException {
+        TableOperations tableOperations = connector.tableOperations();
+        if (!tableOperations.exists(TABLE_METADATA)) {
+            tableOperations.create(TABLE_METADATA);
+        }
+    }
+    
+    private static void addFields(Connector connector) throws TableNotFoundException {
+        BatchWriterConfig config = new BatchWriterConfig();
+        config.setMaxMemory(0);
+        try (BatchWriter writer = connector.createBatchWriter(TABLE_METADATA, config)) {
+            Mutation m = new Mutation("rowA");
+            m.put("t", "dataTypeA", new Value("value"));
+            writer.addMutation(m);
+            writer.flush();
+        } catch (MutationsRejectedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+    
+    @Before
+    public void setup() throws TableNotFoundException, AccumuloException, TableExistsException, AccumuloSecurityException {
+        setupTable(getConnector());
+        addFields(getConnector());
+        mdh = new MetadataHelper(createAllFieldMetadataHelper(getConnector()), Collections.emptySet(), getConnector(), TABLE_METADATA, Collections.emptySet(),
+                        Collections.emptySet());
+    }
+    
+    @Test // we expect our row to be filtered out
+    public void testPopulatedTypeFilter() throws TableNotFoundException {
+        assertEquals(Collections.EMPTY_SET, mdh.getAllFields(Collections.singleton("rowA")));
+    }
+    
+    @Test // we expect a null filter to allow all the things
+    public void testNullTypeFilter() throws TableNotFoundException {
+        assertEquals(Collections.singleton("rowA"), mdh.getAllFields(null));
+    }
+    
+    @Test // we expect an empty filter to allow none of the things
+    public void testEmptyTypeFilter() throws TableNotFoundException {
+        assertEquals(Collections.EMPTY_SET, mdh.getAllFields(Collections.EMPTY_SET));
+    }
+}


### PR DESCRIPTION
These changes are tied to [datawave#1814](https://github.com/NationalSecurityAgency/datawave/pull/1814) as prerequisites for fully removing UniversalSet and handling empty but non-null datatype filters.