### PR TITLE
Reduce TypeMetadata by Fields

### DIFF
--- a/src/main/java/datawave/query/util/TypeMetadata.java
+++ b/src/main/java/datawave/query/util/TypeMetadata.java
@@ -28,8 +28,6 @@ public class TypeMetadata implements Serializable {
     
     protected Map<String,Multimap<String,String>> typeMetadata;
     
-    public static final Multimap<String,String> emptyMap = HashMultimap.create();
-    
     public TypeMetadata() {
         typeMetadata = Maps.newHashMap();
     }
@@ -73,7 +71,7 @@ public class TypeMetadata implements Serializable {
     
     private void addTypeMetadata(String fieldName, String ingestType, Collection<String> types) {
         this.ingestTypes.add(ingestType);
-        fieldNames.add(fieldName);
+        this.fieldNames.add(fieldName);
         if (null == this.typeMetadata.get(ingestType)) {
             Multimap<String,String> typeMap = HashMultimap.create();
             typeMap.putAll(fieldName, types);
@@ -85,7 +83,7 @@ public class TypeMetadata implements Serializable {
     
     private void addTypeMetadata(String fieldName, String ingestType, String type) {
         this.ingestTypes.add(ingestType);
-        fieldNames.add(fieldName);
+        this.fieldNames.add(fieldName);
         if (null == this.typeMetadata.get(ingestType)) {
             Multimap<String,String> typeMap = HashMultimap.create();
             typeMap.put(fieldName, type);
@@ -98,7 +96,7 @@ public class TypeMetadata implements Serializable {
     public Collection<String> getTypeMetadata(String fieldName, String ingestType) {
         Multimap<String,String> map = this.typeMetadata.get(ingestType);
         if (null == map) {
-            return Collections.EMPTY_SET;
+            return Collections.emptySet();
         }
         // defensive copy
         return Sets.newHashSet(map.get(fieldName));
@@ -354,6 +352,7 @@ public class TypeMetadata implements Serializable {
         
         final Multimap<String,String> EMPTY_MULTIMAP = new ImmutableMultimap.Builder().build();
         
+        @Override
         public Collection<String> getTypeMetadata(String fieldName, String ingestType) {
             return Collections.emptySet();
         }
@@ -363,6 +362,7 @@ public class TypeMetadata implements Serializable {
          *
          * @return
          */
+        @Override
         public Multimap<String,String> fold() {
             return EMPTY_MULTIMAP;
         }
@@ -373,6 +373,7 @@ public class TypeMetadata implements Serializable {
          * @param ingestTypeFilter
          * @return
          */
+        @Override
         public Multimap<String,String> fold(Set<String> ingestTypeFilter) {
             return EMPTY_MULTIMAP;
         }
@@ -381,18 +382,22 @@ public class TypeMetadata implements Serializable {
             return Collections.emptySet();
         }
         
+        @Override
         public Set<String> keySet() {
             return Collections.emptySet();
         }
         
+        @Override
         public TypeMetadata filter(Set<String> datatypeFilter) {
             return this;
         }
         
+        @Override
         public boolean equals(Object o) {
             return (o instanceof TypeMetadata) && ((TypeMetadata) o).isEmpty();
         }
         
+        @Override
         public int hashCode() {
             return 0;
         }

--- a/src/main/java/datawave/query/util/TypeMetadata.java
+++ b/src/main/java/datawave/query/util/TypeMetadata.java
@@ -46,14 +46,15 @@ public class TypeMetadata implements Serializable {
         this.ingestTypes.addAll(in.ingestTypes);
         this.fieldNames.addAll(in.fieldNames);
     }
-
+    
     /**
      * Creates a copy of this type metadata object, reducing it down to the set of provided fields
      *
-     * @param fields a set of fields which act as a filter
+     * @param fields
+     *            a set of fields which act as a filter
      * @return a copy of the TypeMetadata filtered down to a set of fields
      */
-    public TypeMetadata reduce(Set<String> fields){
+    public TypeMetadata reduce(Set<String> fields) {
         TypeMetadata reduced = new TypeMetadata();
         for (Entry<String,Multimap<String,String>> entry : typeMetadata.entrySet()) {
             final String ingestType = entry.getKey();

--- a/src/main/java/datawave/query/util/TypeMetadata.java
+++ b/src/main/java/datawave/query/util/TypeMetadata.java
@@ -46,6 +46,27 @@ public class TypeMetadata implements Serializable {
         this.ingestTypes.addAll(in.ingestTypes);
         this.fieldNames.addAll(in.fieldNames);
     }
+
+    /**
+     * Creates a copy of this type metadata object, reducing it down to the set of provided fields
+     *
+     * @param fields a set of fields which act as a filter
+     * @return a copy of the TypeMetadata filtered down to a set of fields
+     */
+    public TypeMetadata reduce(Set<String> fields){
+        TypeMetadata reduced = new TypeMetadata();
+        for (Entry<String,Multimap<String,String>> entry : typeMetadata.entrySet()) {
+            final String ingestType = entry.getKey();
+            for (Entry<String,String> element : entry.getValue().entries()) {
+                final String field = element.getKey();
+                final String normalizer = element.getValue();
+                if (fields.contains(field)) {
+                    reduced.addTypeMetadata(field, ingestType, normalizer);
+                }
+            }
+        }
+        return reduced;
+    }
     
     public void addForAllIngestTypes(Map<String,Set<String>> map) {
         for (String fieldName : map.keySet()) {

--- a/src/test/java/datawave/query/util/TypeMetadataTest.java
+++ b/src/test/java/datawave/query/util/TypeMetadataTest.java
@@ -14,7 +14,7 @@ import static org.junit.Assert.assertTrue;
 public class TypeMetadataTest {
     
     private TypeMetadata typeMetadata;
-
+    
     @Before
     public void setup() {
         typeMetadata = new TypeMetadata();
@@ -57,29 +57,29 @@ public class TypeMetadataTest {
         Set<String> types3 = typeMetadata.getDataTypesForField("");
         assertEquals(0, types3.size());
     }
-
+    
     @Test
-    public void testReduceEmptyTypeMetadata(){
+    public void testReduceEmptyTypeMetadata() {
         TypeMetadata reduced = typeMetadata.reduce(Collections.emptySet());
         assertTrue(reduced.typeMetadata.isEmpty());
     }
-
+    
     @Test
-    public void testReductionNoFieldsMatch(){
+    public void testReductionNoFieldsMatch() {
         TypeMetadata reduced = typeMetadata.reduce(Collections.singleton("FIELD4"));
         assertTrue(reduced.typeMetadata.isEmpty());
     }
-
+    
     @Test
-    public void testReductionSomeFieldsMatch(){
+    public void testReductionSomeFieldsMatch() {
         TypeMetadata reduced = typeMetadata.reduce(Sets.newHashSet("FIELD1", "FIELD2"));
         assertTrue(reduced.keySet().contains("FIELD1"));
         assertTrue(reduced.keySet().contains("FIELD2"));
         assertFalse(reduced.keySet().contains("FIELD3"));
     }
-
+    
     @Test
-    public void testReductionAllFieldsMatch(){
+    public void testReductionAllFieldsMatch() {
         TypeMetadata reduced = typeMetadata.reduce(Sets.newHashSet("FIELD1", "FIELD2", "FIELD3"));
         assertTrue(reduced.keySet().contains("FIELD1"));
         assertTrue(reduced.keySet().contains("FIELD2"));

--- a/src/test/java/datawave/query/util/TypeMetadataTest.java
+++ b/src/test/java/datawave/query/util/TypeMetadataTest.java
@@ -1,17 +1,20 @@
 package datawave.query.util;
 
+import com.google.common.collect.Sets;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Collections;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class TypeMetadataTest {
     
     private TypeMetadata typeMetadata;
-    
+
     @Before
     public void setup() {
         typeMetadata = new TypeMetadata();
@@ -54,5 +57,33 @@ public class TypeMetadataTest {
         Set<String> types3 = typeMetadata.getDataTypesForField("");
         assertEquals(0, types3.size());
     }
-    
+
+    @Test
+    public void testReduceEmptyTypeMetadata(){
+        TypeMetadata reduced = typeMetadata.reduce(Collections.emptySet());
+        assertTrue(reduced.typeMetadata.isEmpty());
+    }
+
+    @Test
+    public void testReductionNoFieldsMatch(){
+        TypeMetadata reduced = typeMetadata.reduce(Collections.singleton("FIELD4"));
+        assertTrue(reduced.typeMetadata.isEmpty());
+    }
+
+    @Test
+    public void testReductionSomeFieldsMatch(){
+        TypeMetadata reduced = typeMetadata.reduce(Sets.newHashSet("FIELD1", "FIELD2"));
+        assertTrue(reduced.keySet().contains("FIELD1"));
+        assertTrue(reduced.keySet().contains("FIELD2"));
+        assertFalse(reduced.keySet().contains("FIELD3"));
+    }
+
+    @Test
+    public void testReductionAllFieldsMatch(){
+        TypeMetadata reduced = typeMetadata.reduce(Sets.newHashSet("FIELD1", "FIELD2", "FIELD3"));
+        assertTrue(reduced.keySet().contains("FIELD1"));
+        assertTrue(reduced.keySet().contains("FIELD2"));
+        assertTrue(reduced.keySet().contains("FIELD3"));
+        assertEquals(reduced, typeMetadata);
+    }
 }


### PR DESCRIPTION
Added a `reduce(Set<String> fields)` method to TypeMetadata. The provided fields act as a filter when copying the existing TypeMetadata.