### PR TITLE
Add functions to retrieve field index holes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,6 +145,11 @@
             <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <repositories>
         <repository>

--- a/src/main/java/datawave/query/model/FieldIndexHole.java
+++ b/src/main/java/datawave/query/model/FieldIndexHole.java
@@ -1,13 +1,16 @@
 package datawave.query.model;
 
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.Objects;
 import java.util.SortedSet;
 import java.util.StringJoiner;
-import java.util.TreeSet;
 
+import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
+
+import com.google.common.collect.ImmutableSortedSet;
 
 /**
  * This class represents a set of calculated field index holes for a given fieldName and datatype. A field index hole is effectively a date where a frequency
@@ -17,11 +20,15 @@ public class FieldIndexHole {
     
     private final String fieldName;
     private final String datatype;
-    private final SortedSet<Pair<Date,Date>> dateRanges = new TreeSet<>();
+    private final SortedSet<Pair<Date,Date>> dateRanges;
     
-    public FieldIndexHole(String fieldName, String dataType) {
+    public FieldIndexHole(String fieldName, String dataType, Collection<Pair<Date,Date>> holes) {
         this.fieldName = fieldName;
         this.datatype = dataType;
+        // Ensure the date range set is immutable.
+        ImmutableSortedSet.Builder<Pair<Date,Date>> builder = new ImmutableSortedSet.Builder<>(Comparator.naturalOrder());
+        holes.forEach(p -> builder.add(new ImmutablePair<>(p.getLeft(), p.getRight())));
+        dateRanges = builder.build();
     }
     
     /**
@@ -50,26 +57,6 @@ public class FieldIndexHole {
      */
     public SortedSet<Pair<Date,Date>> getDateRanges() {
         return dateRanges;
-    }
-    
-    /**
-     * Add a collection of field index hole date ranges to this {@link FieldIndexHole}.
-     * 
-     * @param dateRanges
-     *            the date ranges
-     */
-    public void addDateRanges(Collection<Pair<Date,Date>> dateRanges) {
-        this.dateRanges.addAll(dateRanges);
-    }
-    
-    /**
-     * Add a field index hole date range to this {@link FieldIndexHole}.
-     * 
-     * @param dateRange
-     *            the date range
-     */
-    public void addDateRange(Pair<Date,Date> dateRange) {
-        this.dateRanges.add(dateRange);
     }
     
     @Override

--- a/src/main/java/datawave/query/model/FieldIndexHole.java
+++ b/src/main/java/datawave/query/model/FieldIndexHole.java
@@ -1,0 +1,98 @@
+package datawave.query.model;
+
+import java.util.Collection;
+import java.util.Date;
+import java.util.Objects;
+import java.util.SortedSet;
+import java.util.StringJoiner;
+import java.util.TreeSet;
+
+import org.apache.commons.lang3.tuple.Pair;
+
+/**
+ * This class represents a set of calculated field index holes for a given fieldName and datatype. A field index hole is effectively a date where a frequency
+ * row was seen, but an index and/or reversed indexed row was not.
+ */
+public class FieldIndexHole {
+    
+    private final String fieldName;
+    private final String datatype;
+    private final SortedSet<Pair<Date,Date>> dateRanges = new TreeSet<>();
+    
+    public FieldIndexHole(String fieldName, String dataType) {
+        this.fieldName = fieldName;
+        this.datatype = dataType;
+    }
+    
+    /**
+     * Return the field name.
+     * 
+     * @return the field name.
+     */
+    public String getFieldName() {
+        return fieldName;
+    }
+    
+    /**
+     * Return the datatype.
+     * 
+     * @return the datatype.
+     */
+    public String getDatatype() {
+        return datatype;
+    }
+    
+    /**
+     * Returns the set of date ranges that span over field index holes for the fieldName and datatype of this {@link FieldIndexHole}. Each date range represents
+     * a span of consecutive days for which a frequency row exist, but an index row does not. All date ranges are start(inclusive)-end(inclusive).
+     * 
+     * @return the date ranges
+     */
+    public SortedSet<Pair<Date,Date>> getDateRanges() {
+        return dateRanges;
+    }
+    
+    /**
+     * Add a collection of field index hole date ranges to this {@link FieldIndexHole}.
+     * 
+     * @param dateRanges
+     *            the date ranges
+     */
+    public void addDateRanges(Collection<Pair<Date,Date>> dateRanges) {
+        this.dateRanges.addAll(dateRanges);
+    }
+    
+    /**
+     * Add a field index hole date range to this {@link FieldIndexHole}.
+     * 
+     * @param dateRange
+     *            the date range
+     */
+    public void addDateRange(Pair<Date,Date> dateRange) {
+        this.dateRanges.add(dateRange);
+    }
+    
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        FieldIndexHole indexHole = (FieldIndexHole) o;
+        return Objects.equals(fieldName, indexHole.fieldName) && Objects.equals(datatype, indexHole.datatype)
+                        && Objects.equals(dateRanges, indexHole.dateRanges);
+    }
+    
+    @Override
+    public int hashCode() {
+        return Objects.hash(fieldName, datatype, dateRanges);
+    }
+    
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", FieldIndexHole.class.getSimpleName() + "[", "]").add("fieldName='" + fieldName + "'").add("dataType='" + datatype + "'")
+                        .add("dateRanges=" + dateRanges).toString();
+    }
+}

--- a/src/main/java/datawave/query/util/MetadataHelper.java
+++ b/src/main/java/datawave/query/util/MetadataHelper.java
@@ -43,7 +43,6 @@ import org.apache.accumulo.core.iterators.user.SummingCombiner;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.security.ColumnVisibility;
 import org.apache.commons.lang.time.DateUtils;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.WritableUtils;
 import org.slf4j.Logger;
@@ -1418,20 +1417,20 @@ public class MetadataHelper {
     }
     
     /**
-     * Return the field index holes calculated between all "i" and "f" entries.
-     * 
+     * Return the field index holes calculated between all "i" and "f" entries. The map consists of field names to datatypes to field index holes.
+     *
      * @return the field index holes
      */
-    public Map<Pair<String,String>,FieldIndexHole> getFieldIndexHoles() throws TableNotFoundException, CharacterCodingException {
+    public Map<String,Map<String,FieldIndexHole>> getFieldIndexHoles() throws TableNotFoundException, CharacterCodingException {
         return allFieldMetadataHelper.getFieldIndexHoles();
     }
     
     /**
-     * Return the field index holes calculated between all "ri" and "f" entries.
-     * 
+     * Return the field index holes calculated between all "ri" and "f" entries. The map consists of field names to datatypes to field index holes.
+     *
      * @return the field index holes
      */
-    public Map<Pair<String,String>,FieldIndexHole> getReversedFieldIndexHoles() throws TableNotFoundException, CharacterCodingException {
+    public Map<String,Map<String,FieldIndexHole>> getReversedFieldIndexHoles() throws TableNotFoundException, CharacterCodingException {
         return allFieldMetadataHelper.getReversedFieldIndexHoles();
     }
     

--- a/src/main/java/datawave/query/util/MetadataHelper.java
+++ b/src/main/java/datawave/query/util/MetadataHelper.java
@@ -43,6 +43,7 @@ import org.apache.accumulo.core.iterators.user.SummingCombiner;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.security.ColumnVisibility;
 import org.apache.commons.lang.time.DateUtils;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.WritableUtils;
 import org.slf4j.Logger;
@@ -71,6 +72,7 @@ import datawave.iterators.filter.EdgeMetadataCQStrippingIterator;
 import datawave.marking.MarkingFunctions;
 import datawave.query.composite.CompositeMetadata;
 import datawave.query.model.Direction;
+import datawave.query.model.FieldIndexHole;
 import datawave.query.model.FieldMapping;
 import datawave.query.model.ModelKeyParser;
 import datawave.query.model.QueryModel;
@@ -1413,6 +1415,24 @@ public class MetadataHelper {
         }
         
         return date;
+    }
+    
+    /**
+     * Return the field index holes calculated between all "i" and "f" entries.
+     * 
+     * @return the field index holes
+     */
+    public Map<Pair<String,String>,FieldIndexHole> getFieldIndexHoles() throws TableNotFoundException, CharacterCodingException {
+        return allFieldMetadataHelper.getFieldIndexHoles();
+    }
+    
+    /**
+     * Return the field index holes calculated between all "ri" and "f" entries.
+     * 
+     * @return the field index holes
+     */
+    public Map<Pair<String,String>,FieldIndexHole> getReversedFieldIndexHoles() throws TableNotFoundException, CharacterCodingException {
+        return allFieldMetadataHelper.getReversedFieldIndexHoles();
     }
     
     /**

--- a/src/test/java/datawave/query/util/AllFieldMetadataHelperTest.java
+++ b/src/test/java/datawave/query/util/AllFieldMetadataHelperTest.java
@@ -1,0 +1,359 @@
+package datawave.query.util;
+
+import java.io.File;
+import java.net.URISyntaxException;
+import java.nio.charset.CharacterCodingException;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import org.apache.accumulo.core.client.AccumuloClient;
+import org.apache.accumulo.core.client.AccumuloException;
+import org.apache.accumulo.core.client.AccumuloSecurityException;
+import org.apache.accumulo.core.client.BatchWriter;
+import org.apache.accumulo.core.client.BatchWriterConfig;
+import org.apache.accumulo.core.client.MutationsRejectedException;
+import org.apache.accumulo.core.client.TableExistsException;
+import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.data.Mutation;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.iterators.user.SummingCombiner;
+import org.apache.accumulo.core.security.Authorizations;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import com.google.common.collect.Maps;
+
+import datawave.accumulo.inmemory.InMemoryAccumuloClient;
+import datawave.accumulo.inmemory.InMemoryInstance;
+import datawave.query.composite.CompositeMetadataHelper;
+import datawave.query.model.FieldIndexHole;
+import datawave.util.time.DateHelper;
+
+class AllFieldMetadataHelperTest {
+    
+    private static final String TABLE_METADATA = "metadata";
+    private static final String[] AUTHS = {"FOO"};
+    private static final String NULL_BYTE = "\0";
+    private static final Value NULL_VALUE = new Value(new byte[0]);
+    private AccumuloClient accumuloClient;
+    private AllFieldMetadataHelper helper;
+    
+    @BeforeAll
+    static void beforeAll() throws URISyntaxException {
+        File dir = new File(ClassLoader.getSystemClassLoader().getResource(".").toURI());
+        File targetDir = dir.getParentFile();
+        System.setProperty("hadoop.home.dir", targetDir.getAbsolutePath());
+    }
+    
+    /**
+     * Set up the accumulo client and initialize the helper.
+     */
+    @BeforeEach
+    void setUp() throws AccumuloSecurityException, AccumuloException, TableExistsException {
+        accumuloClient = new InMemoryAccumuloClient("root", new InMemoryInstance(AllFieldMetadataHelper.class.toString()));
+        if (!accumuloClient.tableOperations().exists(TABLE_METADATA)) {
+            accumuloClient.tableOperations().create(TABLE_METADATA);
+        }
+        final Set<Authorizations> allMetadataAuths = Collections.emptySet();
+        final Set<Authorizations> auths = Collections.singleton(new Authorizations(AUTHS));
+        TypeMetadataHelper typeMetadataHelper = new TypeMetadataHelper(Maps.newHashMap(), allMetadataAuths, accumuloClient, TABLE_METADATA, auths, false);
+        CompositeMetadataHelper compositeMetadataHelper = new CompositeMetadataHelper(accumuloClient, TABLE_METADATA, auths);
+        helper = new AllFieldMetadataHelper(typeMetadataHelper, compositeMetadataHelper, accumuloClient, TABLE_METADATA, auths, allMetadataAuths);
+    }
+    
+    /**
+     * Clear the metadata table after each test.
+     */
+    @AfterEach
+    void tearDown() throws AccumuloException, TableNotFoundException, AccumuloSecurityException {
+        accumuloClient.tableOperations().deleteRows(TABLE_METADATA, null, null);
+    }
+    
+    /**
+     * Write the given mutations to the metadata table.
+     */
+    private void writeMutations(Collection<Mutation> mutations) {
+        BatchWriterConfig config = new BatchWriterConfig();
+        config.setMaxMemory(0);
+        try (BatchWriter writer = accumuloClient.createBatchWriter(TABLE_METADATA, config)) {
+            writer.addMutations(mutations);
+            writer.flush();
+        } catch (MutationsRejectedException | TableNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+    
+    /**
+     * Tests for {@link AllFieldMetadataHelper#getFieldIndexHoles()}.
+     */
+    @Nested
+    public class FieldIndexHoleTests {
+        
+        private Supplier<Map<Pair<String,String>,FieldIndexHole>> INDEX_FUNCTION = () -> {
+            try {
+                return helper.getFieldIndexHoles();
+            } catch (TableNotFoundException | CharacterCodingException e) {
+                throw new RuntimeException(e);
+            }
+        };
+        
+        private Supplier<Map<Pair<String,String>,FieldIndexHole>> REVERSED_INDEX_FUNCTION = () -> {
+            try {
+                return helper.getReversedFieldIndexHoles();
+            } catch (TableNotFoundException | CharacterCodingException e) {
+                throw new RuntimeException(e);
+            }
+        };
+        
+        private Supplier<Map<Pair<String,String>,FieldIndexHole>> getIndexHoleFunction(String cf) {
+            return cf.equals("i") ? INDEX_FUNCTION : REVERSED_INDEX_FUNCTION;
+        }
+        
+        /**
+         * Test against data that has no field index holes.
+         */
+        @ParameterizedTest
+        @ValueSource(strings = {"i", "ri"})
+        void testNoFieldIndexHoles(String cf) {
+            // Create a series of frequency rows over date ranges, each with a matching index row for each date.
+            MutationCreator mutationCreator = new MutationCreator();
+            mutationCreator.addFrequencyMutations("NAME", "csv", "20200101", "20200120");
+            mutationCreator.addIndexMutations(cf, "NAME", "csv", "20200101", "20200120");
+            mutationCreator.addFrequencyMutations("NAME", "wiki", "20200101", "20200120");
+            mutationCreator.addIndexMutations(cf, "NAME", "wiki", "20200101", "20200120");
+            mutationCreator.addFrequencyMutations("NAME", "maze", "20200101", "20200120");
+            mutationCreator.addIndexMutations(cf, "NAME", "maze", "20200101", "20200120");
+            mutationCreator.addFrequencyMutations("EVENT_DATE", "csv", "20200101", "20200120");
+            mutationCreator.addIndexMutations(cf, "EVENT_DATE", "csv", "20200101", "20200120");
+            mutationCreator.addFrequencyMutations("EVENT_DATE", "wiki", "20200101", "20200120");
+            mutationCreator.addIndexMutations(cf, "EVENT_DATE", "wiki", "20200101", "20200120");
+            mutationCreator.addFrequencyMutations("EVENT_DATE", "maze", "20200101", "20200120");
+            mutationCreator.addIndexMutations(cf, "EVENT_DATE", "maze", "20200101", "20200120");
+            writeMutations(mutationCreator.getMutations());
+            
+            // Verify that no index holes were found.
+            Map<Pair<String,String>,FieldIndexHole> fieldIndexHoles = getIndexHoleFunction(cf).get();
+            System.out.println(fieldIndexHoles);
+            Assertions.assertTrue(fieldIndexHoles.isEmpty());
+        }
+        
+        /**
+         * Test against data that has field index holes for an entire fieldName-datatype combination.
+         */
+        @ParameterizedTest
+        @ValueSource(strings = {"i", "ri"})
+        void testFieldIndexHoleForEntireFrequencyDateRange(String cf) {
+            MutationCreator mutationCreator = new MutationCreator();
+            mutationCreator.addFrequencyMutations("NAME", "wiki", "20200101", "20200105"); // Do not create matching index rows for these.
+            mutationCreator.addFrequencyMutations("NAME", "csv", "20200101", "20200105");
+            mutationCreator.addIndexMutations(cf, "NAME", "csv", "20200101", "20200105");
+            writeMutations(mutationCreator.getMutations());
+            
+            Map<Pair<String,String>,FieldIndexHole> fieldIndexHoles = getIndexHoleFunction(cf).get();
+            Assertions.assertEquals(1, fieldIndexHoles.size());
+            FieldIndexHole expectedHole = new FieldIndexHole("NAME", "wiki");
+            expectedHole.addDateRange(dateRange("20200101", "20200105"));
+            Assertions.assertEquals(expectedHole, fieldIndexHoles.get(Pair.of("NAME", "wiki")));
+        }
+        
+        /**
+         * Test against data that has a field index hole at the start of a frequency date range for a given fieldName-dataType combination.
+         */
+        @ParameterizedTest
+        @ValueSource(strings = {"i", "ri"})
+        void testFieldIndexHoleForStartOfFrequencyDateRange(String cf) {
+            MutationCreator mutationCreator = new MutationCreator();
+            mutationCreator.addFrequencyMutations("NAME", "wiki", "20200101", "20200105");
+            mutationCreator.addIndexMutations(cf, "NAME", "wiki", "20200104", "20200105");
+            mutationCreator.addFrequencyMutations("NAME", "csv", "20200101", "20200105");
+            mutationCreator.addIndexMutations(cf, "NAME", "csv", "20200101", "20200105");
+            writeMutations(mutationCreator.getMutations());
+            
+            Map<Pair<String,String>,FieldIndexHole> fieldIndexHoles = getIndexHoleFunction(cf).get();
+            Assertions.assertEquals(1, fieldIndexHoles.size());
+            FieldIndexHole expectedHole = new FieldIndexHole("NAME", "wiki");
+            expectedHole.addDateRange(dateRange("20200101", "20200103"));
+            Assertions.assertEquals(expectedHole, fieldIndexHoles.get(Pair.of("NAME", "wiki")));
+        }
+        
+        /**
+         * Test against data that has a field index hole at the end of a frequency date range for a given fieldName-dataType combination.
+         */
+        @ParameterizedTest
+        @ValueSource(strings = {"i", "ri"})
+        void testFieldIndexHoleForEndOfFrequencyDateRange(String cf) {
+            MutationCreator mutationCreator = new MutationCreator();
+            mutationCreator.addFrequencyMutations("NAME", "wiki", "20200101", "20200105");
+            mutationCreator.addIndexMutations(cf, "NAME", "wiki", "20200101", "20200102");
+            mutationCreator.addFrequencyMutations("NAME", "csv", "20200101", "20200105");
+            mutationCreator.addIndexMutations(cf, "NAME", "csv", "20200101", "20200105");
+            writeMutations(mutationCreator.getMutations());
+            
+            Map<Pair<String,String>,FieldIndexHole> fieldIndexHoles = getIndexHoleFunction(cf).get();
+            Assertions.assertEquals(1, fieldIndexHoles.size());
+            FieldIndexHole expectedHole = new FieldIndexHole("NAME", "wiki");
+            expectedHole.addDateRange(dateRange("20200103", "20200105"));
+            Assertions.assertEquals(expectedHole, fieldIndexHoles.get(Pair.of("NAME", "wiki")));
+        }
+        
+        /**
+         * Test against data that has a field index hole in the middle of a frequency date range for a given fieldName-datatype combination.
+         */
+        @ParameterizedTest
+        @ValueSource(strings = {"i", "ri"})
+        void testFieldIndexHoleForMiddleOfFrequencyDateRange(String cf) {
+            MutationCreator mutationCreator = new MutationCreator();
+            mutationCreator.addFrequencyMutations("NAME", "wiki", "20200101", "20200110");
+            mutationCreator.addIndexMutations(cf, "NAME", "wiki", "20200101", "20200103");
+            mutationCreator.addIndexMutations(cf, "NAME", "wiki", "20200107", "20200110");
+            mutationCreator.addFrequencyMutations("NAME", "csv", "20200101", "20200105");
+            mutationCreator.addIndexMutations(cf, "NAME", "csv", "20200101", "20200105");
+            writeMutations(mutationCreator.getMutations());
+            
+            Map<Pair<String,String>,FieldIndexHole> fieldIndexHoles = getIndexHoleFunction(cf).get();
+            Assertions.assertEquals(1, fieldIndexHoles.size());
+            FieldIndexHole expectedHole = new FieldIndexHole("NAME", "wiki");
+            expectedHole.addDateRange(dateRange("20200104", "20200106"));
+            Assertions.assertEquals(expectedHole, fieldIndexHoles.get(Pair.of("NAME", "wiki")));
+        }
+        
+        /**
+         * Test against data that has multiple field index holes for a given fieldName-datatype combination.
+         */
+        @ParameterizedTest
+        @ValueSource(strings = {"i", "ri"})
+        void testMultipleFieldIndexHolesInFrequencyDateRange(String cf) {
+            MutationCreator mutationCreator = new MutationCreator();
+            mutationCreator.addFrequencyMutations("NAME", "wiki", "20200101", "20200120");
+            mutationCreator.addIndexMutations(cf, "NAME", "wiki", "20200104", "20200106");
+            mutationCreator.addIndexMutations(cf, "NAME", "wiki", "20200110", "20200113");
+            mutationCreator.addIndexMutations(cf, "NAME", "wiki", "20200117", "20200118");
+            writeMutations(mutationCreator.getMutations());
+            
+            Map<Pair<String,String>,FieldIndexHole> fieldIndexHoles = getIndexHoleFunction(cf).get();
+            Assertions.assertEquals(1, fieldIndexHoles.size());
+            FieldIndexHole expectedHole = new FieldIndexHole("NAME", "wiki");
+            expectedHole.addDateRange(dateRange("20200101", "20200103"));
+            expectedHole.addDateRange(dateRange("20200107", "20200109"));
+            expectedHole.addDateRange(dateRange("20200114", "20200116"));
+            expectedHole.addDateRange(dateRange("20200119", "20200120"));
+            Assertions.assertEquals(expectedHole, fieldIndexHoles.get(Pair.of("NAME", "wiki")));
+        }
+        
+        /**
+         * Test against data where the expected index hole occurs for the end of a frequency range right before a new fieldName-datatype combination.
+         */
+        @ParameterizedTest
+        @ValueSource(strings = {"i", "ri"})
+        void testFieldIndexHoleAtEndOfFrequencyDateRangeForNonLastCombo(String cf) {
+            MutationCreator mutationCreator = new MutationCreator();
+            mutationCreator.addFrequencyMutations("NAME", "wiki", "20200101", "20200105");
+            mutationCreator.addIndexMutations(cf, "NAME", "wiki", "20200101", "20200102");
+            mutationCreator.addFrequencyMutations("ZETA", "csv", "20200101", "20200105");
+            mutationCreator.addIndexMutations(cf, "ZETA", "csv", "20200101", "20200105");
+            writeMutations(mutationCreator.getMutations());
+            
+            Map<Pair<String,String>,FieldIndexHole> fieldIndexHoles = getIndexHoleFunction(cf).get();
+            Assertions.assertEquals(1, fieldIndexHoles.size());
+            FieldIndexHole expectedHole = new FieldIndexHole("NAME", "wiki");
+            expectedHole.addDateRange(dateRange("20200103", "20200105"));
+            Assertions.assertEquals(expectedHole, fieldIndexHoles.get(Pair.of("NAME", "wiki")));
+        }
+        
+        /**
+         * Test against data where the expected index hole spans across multiple frequency ranges.
+         */
+        @ParameterizedTest
+        @ValueSource(strings = {"i", "ri"})
+        void testFieldIndexHoleSpanningMultipleFrequencyDateRanges(String cf) {
+            MutationCreator mutationCreator = new MutationCreator();
+            mutationCreator.addFrequencyMutations("NAME", "wiki", "20200101", "20200105");
+            mutationCreator.addFrequencyMutations("NAME", "wiki", "20200110", "20200115");
+            mutationCreator.addIndexMutations(cf, "NAME", "wiki", "20200101", "20200103");
+            mutationCreator.addIndexMutations(cf, "NAME", "wiki", "20200113", "20200115");
+            writeMutations(mutationCreator.getMutations());
+            
+            Map<Pair<String,String>,FieldIndexHole> fieldIndexHoles = getIndexHoleFunction(cf).get();
+            Assertions.assertEquals(1, fieldIndexHoles.size());
+            FieldIndexHole expectedHole = new FieldIndexHole("NAME", "wiki");
+            expectedHole.addDateRange(dateRange("20200104", "20200105"));
+            expectedHole.addDateRange(dateRange("20200110", "20200112"));
+            Assertions.assertEquals(expectedHole, fieldIndexHoles.get(Pair.of("NAME", "wiki")));
+        }
+    }
+    
+    private Pair<Date,Date> dateRange(String start, String end) {
+        return Pair.of(DateHelper.parse(start), DateHelper.parse(end));
+    }
+    
+    /**
+     * Helper class for creating mutations in bulk.
+     */
+    private static class MutationCreator {
+        
+        private final List<Mutation> mutations = new ArrayList<>();
+        
+        private void addFrequencyMutations(String fieldName, String datatype, String startDate, String endDate) {
+            List<String> dates = getDatesInRange(startDate, endDate);
+            dates.forEach(date -> addFrequencyMutation(fieldName, datatype, date));
+        }
+        
+        private void addFrequencyMutation(String fieldName, String datatype, String date) {
+            addMutation(fieldName, "f", datatype + NULL_BYTE + date, new Value(SummingCombiner.VAR_LEN_ENCODER.encode(1L)));
+        }
+        
+        private void addIndexMutations(String cf, String fieldName, String datatype, String startDate, String endDate) {
+            List<String> dates = getDatesInRange(startDate, endDate);
+            dates.forEach(date -> addIndexMutation(cf, fieldName, datatype, date));
+        }
+        
+        private void addIndexMutation(String cf, String fieldName, String datatype, String date) {
+            addMutation(fieldName, cf, datatype + NULL_BYTE + date, NULL_VALUE);
+        }
+        
+        private List<String> getDatesInRange(String startDateStr, String endDateStr) {
+            Date startDate = DateHelper.parse(startDateStr);
+            Date endDate = DateHelper.parse(endDateStr);
+            
+            List<String> dates = new ArrayList<>();
+            dates.add(startDateStr);
+            
+            Calendar calendar = Calendar.getInstance();
+            calendar.setTime(startDate);
+            while (true) {
+                calendar.add(Calendar.DAY_OF_MONTH, 1);
+                Date date = calendar.getTime();
+                if (date.before(endDate) || date.equals(endDate)) {
+                    dates.add(DateHelper.format(date));
+                } else {
+                    break;
+                }
+            }
+            
+            return dates;
+        }
+        
+        private void addMutation(String row, String columnFamily, String columnQualifier, Value value) {
+            Mutation mutation = new Mutation(row);
+            mutation.put(columnFamily, columnQualifier, value);
+            mutations.add(mutation);
+        }
+        
+        private List<Mutation> getMutations() {
+            return mutations;
+        }
+    }
+}

--- a/src/test/java/datawave/query/util/AllFieldMetadataHelperTest.java
+++ b/src/test/java/datawave/query/util/AllFieldMetadataHelperTest.java
@@ -11,6 +11,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Supplier;
 
@@ -55,7 +56,7 @@ class AllFieldMetadataHelperTest {
     
     @BeforeAll
     static void beforeAll() throws URISyntaxException {
-        File dir = new File(ClassLoader.getSystemClassLoader().getResource(".").toURI());
+        File dir = new File(Objects.requireNonNull(ClassLoader.getSystemClassLoader().getResource(".")).toURI());
         File targetDir = dir.getParentFile();
         System.setProperty("hadoop.home.dir", targetDir.getAbsolutePath());
     }
@@ -101,7 +102,6 @@ class AllFieldMetadataHelperTest {
     /**
      * Tests for {@link AllFieldMetadataHelper#getFieldIndexHoles()}.
      */
-    @SuppressWarnings("unchecked")
     @Nested
     public class FieldIndexHoleTests {
         

--- a/src/test/java/datawave/query/util/AllFieldMetadataHelperTest.java
+++ b/src/test/java/datawave/query/util/AllFieldMetadataHelperTest.java
@@ -8,6 +8,7 @@ import java.util.Calendar;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -35,6 +36,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 
 import datawave.accumulo.inmemory.InMemoryAccumuloClient;
 import datawave.accumulo.inmemory.InMemoryInstance;
@@ -99,10 +101,11 @@ class AllFieldMetadataHelperTest {
     /**
      * Tests for {@link AllFieldMetadataHelper#getFieldIndexHoles()}.
      */
+    @SuppressWarnings("unchecked")
     @Nested
     public class FieldIndexHoleTests {
         
-        private Supplier<Map<Pair<String,String>,FieldIndexHole>> INDEX_FUNCTION = () -> {
+        private final Supplier<Map<String,Map<String,FieldIndexHole>>> INDEX_FUNCTION = () -> {
             try {
                 return helper.getFieldIndexHoles();
             } catch (TableNotFoundException | CharacterCodingException e) {
@@ -110,7 +113,7 @@ class AllFieldMetadataHelperTest {
             }
         };
         
-        private Supplier<Map<Pair<String,String>,FieldIndexHole>> REVERSED_INDEX_FUNCTION = () -> {
+        private final Supplier<Map<String,Map<String,FieldIndexHole>>> REVERSED_INDEX_FUNCTION = () -> {
             try {
                 return helper.getReversedFieldIndexHoles();
             } catch (TableNotFoundException | CharacterCodingException e) {
@@ -118,7 +121,7 @@ class AllFieldMetadataHelperTest {
             }
         };
         
-        private Supplier<Map<Pair<String,String>,FieldIndexHole>> getIndexHoleFunction(String cf) {
+        private Supplier<Map<String,Map<String,FieldIndexHole>>> getIndexHoleFunction(String cf) {
             return cf.equals("i") ? INDEX_FUNCTION : REVERSED_INDEX_FUNCTION;
         }
         
@@ -145,8 +148,7 @@ class AllFieldMetadataHelperTest {
             writeMutations(mutationCreator.getMutations());
             
             // Verify that no index holes were found.
-            Map<Pair<String,String>,FieldIndexHole> fieldIndexHoles = getIndexHoleFunction(cf).get();
-            System.out.println(fieldIndexHoles);
+            Map<String,Map<String,FieldIndexHole>> fieldIndexHoles = getIndexHoleFunction(cf).get();
             Assertions.assertTrue(fieldIndexHoles.isEmpty());
         }
         
@@ -162,11 +164,11 @@ class AllFieldMetadataHelperTest {
             mutationCreator.addIndexMutations(cf, "NAME", "csv", "20200101", "20200105");
             writeMutations(mutationCreator.getMutations());
             
-            Map<Pair<String,String>,FieldIndexHole> fieldIndexHoles = getIndexHoleFunction(cf).get();
-            Assertions.assertEquals(1, fieldIndexHoles.size());
-            FieldIndexHole expectedHole = new FieldIndexHole("NAME", "wiki");
-            expectedHole.addDateRange(dateRange("20200101", "20200105"));
-            Assertions.assertEquals(expectedHole, fieldIndexHoles.get(Pair.of("NAME", "wiki")));
+            Map<String,Map<String,FieldIndexHole>> fieldIndexHoles = getIndexHoleFunction(cf).get();
+            // @formatter:on
+            Map<String,Map<String,FieldIndexHole>> expected = createFieldIndexHoleMap(createFieldIndexHole("NAME", "wiki", dateRange("20200101", "20200105")));
+            // @formatter:off
+            Assertions.assertEquals(expected, fieldIndexHoles);
         }
         
         /**
@@ -181,12 +183,12 @@ class AllFieldMetadataHelperTest {
             mutationCreator.addFrequencyMutations("NAME", "csv", "20200101", "20200105");
             mutationCreator.addIndexMutations(cf, "NAME", "csv", "20200101", "20200105");
             writeMutations(mutationCreator.getMutations());
-            
-            Map<Pair<String,String>,FieldIndexHole> fieldIndexHoles = getIndexHoleFunction(cf).get();
-            Assertions.assertEquals(1, fieldIndexHoles.size());
-            FieldIndexHole expectedHole = new FieldIndexHole("NAME", "wiki");
-            expectedHole.addDateRange(dateRange("20200101", "20200103"));
-            Assertions.assertEquals(expectedHole, fieldIndexHoles.get(Pair.of("NAME", "wiki")));
+    
+            Map<String,Map<String,FieldIndexHole>> fieldIndexHoles = getIndexHoleFunction(cf).get();
+            // @formatter:on
+            Map<String,Map<String,FieldIndexHole>> expected = createFieldIndexHoleMap(createFieldIndexHole("NAME", "wiki", dateRange("20200101", "20200103")));
+            // @formatter:off
+            Assertions.assertEquals(expected, fieldIndexHoles);
         }
         
         /**
@@ -202,11 +204,11 @@ class AllFieldMetadataHelperTest {
             mutationCreator.addIndexMutations(cf, "NAME", "csv", "20200101", "20200105");
             writeMutations(mutationCreator.getMutations());
             
-            Map<Pair<String,String>,FieldIndexHole> fieldIndexHoles = getIndexHoleFunction(cf).get();
-            Assertions.assertEquals(1, fieldIndexHoles.size());
-            FieldIndexHole expectedHole = new FieldIndexHole("NAME", "wiki");
-            expectedHole.addDateRange(dateRange("20200103", "20200105"));
-            Assertions.assertEquals(expectedHole, fieldIndexHoles.get(Pair.of("NAME", "wiki")));
+            Map<String,Map<String,FieldIndexHole>> fieldIndexHoles = getIndexHoleFunction(cf).get();
+            // @formatter:on
+            Map<String,Map<String,FieldIndexHole>> expected = createFieldIndexHoleMap(createFieldIndexHole("NAME", "wiki", dateRange("20200103", "20200105")));
+            // @formatter:off
+            Assertions.assertEquals(expected, fieldIndexHoles);
         }
         
         /**
@@ -222,12 +224,12 @@ class AllFieldMetadataHelperTest {
             mutationCreator.addFrequencyMutations("NAME", "csv", "20200101", "20200105");
             mutationCreator.addIndexMutations(cf, "NAME", "csv", "20200101", "20200105");
             writeMutations(mutationCreator.getMutations());
-            
-            Map<Pair<String,String>,FieldIndexHole> fieldIndexHoles = getIndexHoleFunction(cf).get();
-            Assertions.assertEquals(1, fieldIndexHoles.size());
-            FieldIndexHole expectedHole = new FieldIndexHole("NAME", "wiki");
-            expectedHole.addDateRange(dateRange("20200104", "20200106"));
-            Assertions.assertEquals(expectedHole, fieldIndexHoles.get(Pair.of("NAME", "wiki")));
+    
+            Map<String,Map<String,FieldIndexHole>> fieldIndexHoles = getIndexHoleFunction(cf).get();
+            // @formatter:on
+            Map<String,Map<String,FieldIndexHole>> expected = createFieldIndexHoleMap(createFieldIndexHole("NAME", "wiki", dateRange("20200104", "20200106")));
+            // @formatter:off
+            Assertions.assertEquals(expected, fieldIndexHoles);
         }
         
         /**
@@ -242,15 +244,16 @@ class AllFieldMetadataHelperTest {
             mutationCreator.addIndexMutations(cf, "NAME", "wiki", "20200110", "20200113");
             mutationCreator.addIndexMutations(cf, "NAME", "wiki", "20200117", "20200118");
             writeMutations(mutationCreator.getMutations());
-            
-            Map<Pair<String,String>,FieldIndexHole> fieldIndexHoles = getIndexHoleFunction(cf).get();
-            Assertions.assertEquals(1, fieldIndexHoles.size());
-            FieldIndexHole expectedHole = new FieldIndexHole("NAME", "wiki");
-            expectedHole.addDateRange(dateRange("20200101", "20200103"));
-            expectedHole.addDateRange(dateRange("20200107", "20200109"));
-            expectedHole.addDateRange(dateRange("20200114", "20200116"));
-            expectedHole.addDateRange(dateRange("20200119", "20200120"));
-            Assertions.assertEquals(expectedHole, fieldIndexHoles.get(Pair.of("NAME", "wiki")));
+    
+            Map<String,Map<String,FieldIndexHole>> fieldIndexHoles = getIndexHoleFunction(cf).get();
+            // @formatter:off
+            Map<String,Map<String,FieldIndexHole>> expected = createFieldIndexHoleMap(
+                            createFieldIndexHole("NAME", "wiki", dateRange("20200101", "20200103"),
+                                            dateRange("20200107", "20200109"),
+                                            dateRange("20200114", "20200116"),
+                                            dateRange("20200119", "20200120")));
+            // @formatter:on
+            Assertions.assertEquals(expected, fieldIndexHoles);
         }
         
         /**
@@ -266,11 +269,12 @@ class AllFieldMetadataHelperTest {
             mutationCreator.addIndexMutations(cf, "ZETA", "csv", "20200101", "20200105");
             writeMutations(mutationCreator.getMutations());
             
-            Map<Pair<String,String>,FieldIndexHole> fieldIndexHoles = getIndexHoleFunction(cf).get();
-            Assertions.assertEquals(1, fieldIndexHoles.size());
-            FieldIndexHole expectedHole = new FieldIndexHole("NAME", "wiki");
-            expectedHole.addDateRange(dateRange("20200103", "20200105"));
-            Assertions.assertEquals(expectedHole, fieldIndexHoles.get(Pair.of("NAME", "wiki")));
+            Map<String,Map<String,FieldIndexHole>> fieldIndexHoles = getIndexHoleFunction(cf).get();
+            // @formatter:off
+            Map<String,Map<String,FieldIndexHole>> expected = createFieldIndexHoleMap(
+                            createFieldIndexHole("NAME", "wiki", dateRange("20200103", "20200105")));
+            // @formatter:on
+            Assertions.assertEquals(expected, fieldIndexHoles);
         }
         
         /**
@@ -286,13 +290,90 @@ class AllFieldMetadataHelperTest {
             mutationCreator.addIndexMutations(cf, "NAME", "wiki", "20200113", "20200115");
             writeMutations(mutationCreator.getMutations());
             
-            Map<Pair<String,String>,FieldIndexHole> fieldIndexHoles = getIndexHoleFunction(cf).get();
-            Assertions.assertEquals(1, fieldIndexHoles.size());
-            FieldIndexHole expectedHole = new FieldIndexHole("NAME", "wiki");
-            expectedHole.addDateRange(dateRange("20200104", "20200105"));
-            expectedHole.addDateRange(dateRange("20200110", "20200112"));
-            Assertions.assertEquals(expectedHole, fieldIndexHoles.get(Pair.of("NAME", "wiki")));
+            Map<String,Map<String,FieldIndexHole>> fieldIndexHoles = getIndexHoleFunction(cf).get();
+            // @formatter:off
+            Map<String,Map<String,FieldIndexHole>> expected = createFieldIndexHoleMap(
+                            createFieldIndexHole("NAME", "wiki", dateRange("20200104", "20200105"), dateRange("20200110", "20200112")));
+            // @formatter:on
+            Assertions.assertEquals(expected, fieldIndexHoles);
         }
+        
+        /**
+         * Test against data where everything is an index hole.
+         */
+        @ParameterizedTest
+        @ValueSource(strings = {"i", "ri"})
+        void testAllDatesAreIndexHoles(String cf) {
+            MutationCreator mutationCreator = new MutationCreator();
+            mutationCreator.addFrequencyMutations("NAME", "wiki", "20200101", "20200105");
+            mutationCreator.addFrequencyMutations("NAME", "csv", "20200110", "20200115");
+            mutationCreator.addFrequencyMutations("EVENT_DATE", "wiki", "20200120", "20200125");
+            mutationCreator.addFrequencyMutations("URI", "maze", "20200216", "20200328");
+            writeMutations(mutationCreator.getMutations());
+            
+            Map<String,Map<String,FieldIndexHole>> fieldIndexHoles = getIndexHoleFunction(cf).get();
+            // @formatter:off
+            Map<String,Map<String,FieldIndexHole>> expected = createFieldIndexHoleMap(
+                            createFieldIndexHole("NAME", "wiki", dateRange("20200101", "20200105")),
+                            createFieldIndexHole("NAME", "csv", dateRange("20200110", "20200115")),
+                            createFieldIndexHole("EVENT_DATE", "wiki", dateRange("20200120", "20200125")),
+                            createFieldIndexHole("URI", "maze", dateRange("20200216", "20200328")));
+            // @formatter:on
+            Assertions.assertEquals(expected, fieldIndexHoles);
+        }
+        
+        /**
+         * Test against data where we have a number of index holes that span just a day.
+         */
+        @ParameterizedTest
+        @ValueSource(strings = {"i", "ri"})
+        void testSingularDayIndexHoles(String cf) {
+            MutationCreator mutationCreator = new MutationCreator();
+            // Index holes for NAME-wiki on 20200103 and 20200105.
+            mutationCreator.addFrequencyMutations("NAME", "wiki", "20200101", "20200105");
+            mutationCreator.addIndexMutations(cf, "NAME", "wiki", "20200101", "20200102");
+            mutationCreator.addIndexMutations(cf, "NAME", "wiki", "20200104", "20200104");
+            // Index holes for NAME-csv on 20200110 and 20200113.
+            mutationCreator.addFrequencyMutations("NAME", "csv", "20200110", "20200115");
+            mutationCreator.addIndexMutations(cf, "NAME", "csv", "20200111", "20200112");
+            mutationCreator.addIndexMutations(cf, "NAME", "csv", "20200114", "20200115");
+            // Index hole for EVENT_DATE-wiki on 20200122.
+            mutationCreator.addFrequencyMutations("EVENT_DATE", "wiki", "20200120", "20200125");
+            mutationCreator.addIndexMutations(cf, "EVENT_DATE", "wiki", "20200120", "20200121");
+            mutationCreator.addIndexMutations(cf, "EVENT_DATE", "wiki", "20200123", "20200125");
+            // Index holes for URI-maze on 20200221, 20200303, and 20200316.
+            mutationCreator.addFrequencyMutations("URI", "maze", "20200216", "20200328");
+            mutationCreator.addIndexMutations(cf, "URI", "maze", "20200216", "20200220");
+            mutationCreator.addIndexMutations(cf, "URI", "maze", "20200222", "20200302");
+            mutationCreator.addIndexMutations(cf, "URI", "maze", "20200304", "20200315");
+            mutationCreator.addIndexMutations(cf, "URI", "maze", "20200317", "20200328");
+            writeMutations(mutationCreator.getMutations());
+            
+            Map<String,Map<String,FieldIndexHole>> fieldIndexHoles = getIndexHoleFunction(cf).get();
+            // @formatter:off
+            Map<String,Map<String,FieldIndexHole>> expected = createFieldIndexHoleMap(
+                            createFieldIndexHole("NAME", "wiki", dateRange("20200103", "20200103"), dateRange("20200105", "20200105")),
+                            createFieldIndexHole("NAME", "csv", dateRange("20200110", "20200110"), dateRange("20200113", "20200113")),
+                            createFieldIndexHole("EVENT_DATE", "wiki", dateRange("20200122", "20200122")),
+                            createFieldIndexHole("URI", "maze", dateRange("20200221", "20200221"), dateRange("20200303", "20200303"),
+                                            dateRange("20200316", "20200316")));
+            // @formatter:on
+            Assertions.assertEquals(expected, fieldIndexHoles);
+        }
+    }
+    
+    private Map<String,Map<String,FieldIndexHole>> createFieldIndexHoleMap(FieldIndexHole... holes) {
+        Map<String,Map<String,FieldIndexHole>> fieldIndexHoles = new HashMap<>();
+        for (FieldIndexHole hole : holes) {
+            Map<String,FieldIndexHole> datatypeMap = fieldIndexHoles.computeIfAbsent(hole.getFieldName(), k -> new HashMap<>());
+            datatypeMap.put(hole.getDatatype(), hole);
+        }
+        return fieldIndexHoles;
+    }
+    
+    @SafeVarargs
+    private FieldIndexHole createFieldIndexHole(String field, String datatype, Pair<Date,Date>... dateRanges) {
+        return new FieldIndexHole(field, datatype, Sets.newHashSet(dateRanges));
     }
     
     private Pair<Date,Date> dateRange(String start, String end) {


### PR DESCRIPTION
Add functionality to retrieve field index holes for index rows and reversed index rows from the metadata table.

Required to support work for #825.