### PR TITLE
fixed #2444: Added the ability to specify index markers of the following form

### DIFF
--- a/src/main/java/datawave/query/util/AllFieldMetadataHelper.java
+++ b/src/main/java/datawave/query/util/AllFieldMetadataHelper.java
@@ -1332,6 +1332,31 @@ public class AllFieldMetadataHelper {
         return indexHoles;
     }
     
+    private static class FieldCount {
+        private long count = 0;
+        private Boolean boundaryValue;
+        
+        public void increment(long value) {
+            this.count += value;
+        }
+        
+        public void setBoundaryValue(boolean boundaryValue) {
+            this.boundaryValue = boundaryValue;
+        }
+        
+        public boolean isBoundary() {
+            return this.boundaryValue != null;
+        }
+        
+        public boolean getBoundaryValue() {
+            return this.boundaryValue;
+        }
+        
+        public long getCount() {
+            return this.count;
+        }
+    }
+    
     /**
      * Utility class for finding field index holes.
      */
@@ -1345,14 +1370,14 @@ public class AllFieldMetadataHelper {
         private final boolean filterDatatypes;
         
         // Contains datatypes to dates and counts for entries seen in "f" rows for the current field name.
-        private final Map<String,SortedMap<Date,Long>> frequencyMap = new HashMap<>();
+        private final Map<String,SortedMap<Date,FieldCount>> frequencyMap = new HashMap<>();
         
         // Contains datatypes to dates and counts for entries seen in the target "i" or "ri" index rows for the current field name.
-        private final Map<String,SortedMap<Date,Long>> indexMap = new HashMap<>();
+        private final Map<String,SortedMap<Date,FieldCount>> indexMap = new HashMap<>();
         
         // Points to the target map object that we add entries to. This changes when we see a different column family compared to the previous row when scanning
         // over entries. We must initially start adding entries to the frequency map.
-        private Map<String,SortedMap<Date,Long>> targetMap = frequencyMap;
+        private Map<String,SortedMap<Date,FieldCount>> targetMap = frequencyMap;
         
         // Map of field names to maps of datatypes to date ranges encompassing field index holes.
         Map<String,Multimap<String,Pair<Date,Date>>> fieldIndexHoles = new HashMap<>();
@@ -1385,7 +1410,8 @@ public class AllFieldMetadataHelper {
             String currDatatype;
             Text currColumnFamily;
             Date currDate;
-            Long currCount;
+            long currCount;
+            Boolean currBoundaryValue;
             
             for (Map.Entry<Key,Value> entry : scanner) {
                 // Parse the current row.
@@ -1395,6 +1421,11 @@ public class AllFieldMetadataHelper {
                 
                 String cq = key.getColumnQualifier().toString();
                 int offset = cq.indexOf(NULL_BYTE);
+                if (offset < 0) {
+                    // we can assume this is an entry of the older format (perhaps the value aggregation is not being applied)
+                    log.error("Found an index entry missing the date: " + key);
+                    continue;
+                }
                 currDatatype = cq.substring(0, offset);
                 
                 // Check if the current field and datatype are part of the fields and datatypes we want to retrieve field index holes for.
@@ -1402,21 +1433,29 @@ public class AllFieldMetadataHelper {
                     continue;
                 }
                 
-                currDate = DateHelper.parse(cq.substring((offset + 1)));
+                String cqRemainder = cq.substring((offset + 1));
+                // check for a marker of <dt>\0<date>\0true/false vs just <dt>\0<date>
+                // where the boolean denotes that we can assume the field is indexed/no on and before this date
+                offset = cqRemainder.indexOf(NULL_BYTE);
+                if (offset >= 0) {
+                    currBoundaryValue = Boolean.valueOf(cqRemainder.substring(offset + 1));
+                    currDate = DateHelper.parse(cqRemainder.substring(0, offset));
+                    currCount = 0;
+                } else {
+                    currBoundaryValue = null;
+                    currDate = DateHelper.parse(cqRemainder);
+                    ByteArrayInputStream byteStream = new ByteArrayInputStream(entry.getValue().get());
+                    DataInputStream inputStream = new DataInputStream(byteStream);
+                    currCount = WritableUtils.readVLong(inputStream);
+                }
                 
-                ByteArrayInputStream byteStream = new ByteArrayInputStream(entry.getValue().get());
-                DataInputStream inputStream = new DataInputStream(byteStream);
-                currCount = WritableUtils.readVLong(inputStream);
-                
-                // If this is the very first entry we've looked at, update our tracking variables, add the current entry to the target map, and continue to the
-                // next
-                // entry.
+                // If this is the very first entry we've looked at, update our tracking variables
                 if (prevFieldName == null) {
-                    addToTargetMap(currDatatype, currDate, currCount);
-                    
                     prevFieldName = currFieldName;
-                    prevColumnFamily = currColumnFamily;
-                    continue;
+                    // assume we are starting with the COLF_F entries
+                    prevColumnFamily = ColumnFamilyConstants.COLF_F;
+                    // Set the target map to the frequency map.
+                    this.targetMap = frequencyMap;
                 }
                 
                 // The column family is different. We have two possible scenarios:
@@ -1441,7 +1480,7 @@ public class AllFieldMetadataHelper {
                     }
                     
                     // Add the current entry to the target entry map.
-                    addToTargetMap(currDatatype, currDate, currCount);
+                    addToTargetMap(currDatatype, currDate, currCount, currBoundaryValue);
                 } else {
                     // The column family is the same. We have two possible scenarios:
                     // - A row with a field that is different to the previous field.
@@ -1454,10 +1493,10 @@ public class AllFieldMetadataHelper {
                         // Clear the entry maps.
                         clearEntryMaps();
                         // Add the current entry to the target entry map.
-                        addToTargetMap(currDatatype, currDate, currCount);
+                        addToTargetMap(currDatatype, currDate, currCount, currBoundaryValue);
                     } else {
                         // The current row has the same field. Add the current entry to the target map.
-                        addToTargetMap(currDatatype, currDate, currCount);
+                        addToTargetMap(currDatatype, currDate, currCount, currBoundaryValue);
                     }
                 }
                 
@@ -1483,9 +1522,32 @@ public class AllFieldMetadataHelper {
         /**
          * Add the current date and count to the current target map for the current datatype.
          */
-        private void addToTargetMap(String datatype, Date date, Long count) {
-            SortedMap<Date,Long> datesToCounts = targetMap.computeIfAbsent(datatype, k -> new TreeMap<>());
-            datesToCounts.put(date, count);
+        private void addToTargetMap(String datatype, Date date, long count, Boolean boundaryValue) {
+            FieldCount fieldCount = getFieldCount(targetMap, datatype, date);
+            fieldCount.increment(count);
+            if (boundaryValue != null) {
+                fieldCount.setBoundaryValue(boundaryValue);
+            }
+            
+            // we need to ensure we have a frequency entry if a boundary so that we will catch this when finding holes
+            getFieldCount(frequencyMap, datatype, date);
+        }
+        
+        /**
+         * Return the field count entry from the specified map. A new entry is added to the map if missing
+         * 
+         * @param datatype
+         * @param date
+         * @return The field count. Never null
+         */
+        private FieldCount getFieldCount(Map<String,SortedMap<Date,FieldCount>> map, String datatype, Date date) {
+            SortedMap<Date,FieldCount> datesToCounts = map.computeIfAbsent(datatype, (k) -> new TreeMap<>());
+            FieldCount fieldCount = datesToCounts.get(date);
+            if (fieldCount == null) {
+                fieldCount = new FieldCount();
+                datesToCounts.put(date, fieldCount);
+            }
+            return fieldCount;
         }
         
         /**
@@ -1514,7 +1576,7 @@ public class AllFieldMetadataHelper {
                 } else {
                     // No corresponding index rows were seen for any of the frequency rows. Each date is an index hole. Add a date range of the earliest date to
                     // the latest date.
-                    SortedMap<Date,Long> entryMap = frequencyMap.get(datatype);
+                    SortedMap<Date,FieldCount> entryMap = frequencyMap.get(datatype);
                     indexHoles.put(datatype, Pair.of(entryMap.firstKey(), entryMap.lastKey()));
                 }
             }
@@ -1529,7 +1591,7 @@ public class AllFieldMetadataHelper {
          *            the index entries
          * @return a set of index holes, possibly empty, but never null
          */
-        private Set<Pair<Date,Date>> getIndexHoles(SortedMap<Date,Long> frequencyMap, SortedMap<Date,Long> indexMap) {
+        private Set<Pair<Date,Date>> getIndexHoles(SortedMap<Date,FieldCount> frequencyMap, SortedMap<Date,FieldCount> indexMap) {
             Set<Pair<Date,Date>> indexHoles = new HashSet<>();
             Date holeStartDate = null;
             Date prevDate = null;
@@ -1537,8 +1599,21 @@ public class AllFieldMetadataHelper {
             for (Date date : frequencyMap.keySet()) {
                 // There is a corresponding index entry for the current date.
                 if (indexMap.containsKey(date)) {
-                    // The count for the current index entry meets the minimum threshold.
-                    if (meetsMinThreshold(frequencyMap.get(date), indexMap.get(date))) {
+                    FieldCount indexCount = indexMap.get(date);
+                    
+                    // if this is a boundary marker, then replace/clear map thus far
+                    if (indexCount.isBoundary()) {
+                        // all holes thus far are to be replaced
+                        indexHoles.clear();
+                        // if not indexed, then start a hole since the beginning
+                        if (!indexCount.getBoundaryValue()) {
+                            holeStartDate = frequencyMap.firstKey();
+                        } else {
+                            // else indexed since the beginning
+                            holeStartDate = null;
+                        }
+                    } else if (meetsMinThreshold(frequencyMap.get(date), indexCount)) {
+                        // The count for the current index entry meets the minimum threshold.
                         // The previous entry was part of an index hole. Capture the index hole range.
                         if (holeStartDate != null) {
                             indexHoles.add(Pair.of(holeStartDate, prevDate));
@@ -1580,12 +1655,12 @@ public class AllFieldMetadataHelper {
          *            the index count
          * @return true if the threshold is met, or false otherwise
          */
-        private boolean meetsMinThreshold(Long frequencyCount, Long indexCount) {
-            if (indexCount >= frequencyCount) {
+        private boolean meetsMinThreshold(FieldCount frequencyCount, FieldCount indexCount) {
+            if (indexCount.getCount() >= frequencyCount.getCount()) {
                 return true;
             }
             
-            double percentage = indexCount.doubleValue() / frequencyCount;
+            double percentage = (double) (indexCount.getCount()) / frequencyCount.getCount();
             return percentage >= minThreshold;
         }
         


### PR DESCRIPTION
<field> i/ri <datatype>\0<date>\0true/false
if true, then we can assume the field is indexed up through that date.
if false, then we can assume the field is not indexed up through that date.
* Added test cases for index marker