### PR TITLE
Avoid useless object creation by delegating to TypeFactory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <version.easymock>4.0.2</version.easymock>
         <version.kryo>2.20</version.kryo>
         <version.powermock>2.0.2</version.powermock>
-        <version.type-utils>3.0.0</version.type-utils>
+        <version.type-utils>3.0.2</version.type-utils>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/src/main/java/datawave/query/util/AllFieldMetadataHelper.java
+++ b/src/main/java/datawave/query/util/AllFieldMetadataHelper.java
@@ -91,7 +91,9 @@ public class AllFieldMetadataHelper {
     protected final TypeMetadataHelper typeMetadataHelper;
     protected final CompositeMetadataHelper compositeMetadataHelper;
     
-    protected final TypeFactory typeFactory = new TypeFactory();
+    private int typeCacheSize = -1;
+    private int typeCacheExpirationInMinutes = -1;
+    protected TypeFactory typeFactory = null;
     
     /**
      * Initializes the instance with a provided update interval.
@@ -734,7 +736,7 @@ public class AllFieldMetadataHelper {
      *             if the class is not accessible
      */
     protected Type<?> getDatatypeFromClass(Class<? extends Type<?>> datatypeClass) throws InstantiationException, IllegalAccessException {
-        return typeFactory.createType(datatypeClass.getName());
+        return getTypeFactory().createType(datatypeClass.getName());
     }
     
     /**
@@ -1366,6 +1368,22 @@ public class AllFieldMetadataHelper {
         return indexHoles;
     }
     
+    public int getTypeCacheSize() {
+        return typeCacheSize;
+    }
+    
+    public void setTypeCacheSize(int typeCacheSize) {
+        this.typeCacheSize = typeCacheSize;
+    }
+    
+    public int getTypeCacheExpirationInMinutes() {
+        return typeCacheExpirationInMinutes;
+    }
+    
+    public void setTypeCacheExpirationInMinutes(int typeCacheExpirationInMinutes) {
+        this.typeCacheExpirationInMinutes = typeCacheExpirationInMinutes;
+    }
+    
     private static class FieldCount {
         private long count = 0;
         private Boolean boundaryValue;
@@ -1793,4 +1811,21 @@ public class AllFieldMetadataHelper {
         return getKey(this);
     }
     
+    /**
+     * Simple 'get or create' method for the TypeFactory
+     *
+     * @return a TypeFactory.
+     */
+    protected TypeFactory getTypeFactory() {
+        if (typeFactory == null) {
+            
+            // check for configured size and TTL
+            if (typeCacheSize != -1 && typeCacheExpirationInMinutes != -1) {
+                typeFactory = new TypeFactory(typeCacheSize, typeCacheExpirationInMinutes);
+            } else {
+                typeFactory = new TypeFactory();
+            }
+        }
+        return typeFactory;
+    }
 }

--- a/src/main/java/datawave/query/util/AllFieldMetadataHelper.java
+++ b/src/main/java/datawave/query/util/AllFieldMetadataHelper.java
@@ -57,6 +57,7 @@ import com.google.common.collect.Sets;
 
 import datawave.data.ColumnFamilyConstants;
 import datawave.data.type.Type;
+import datawave.data.type.TypeFactory;
 import datawave.query.composite.CompositeMetadata;
 import datawave.query.composite.CompositeMetadataHelper;
 import datawave.query.model.FieldIndexHole;
@@ -89,6 +90,8 @@ public class AllFieldMetadataHelper {
     
     protected final TypeMetadataHelper typeMetadataHelper;
     protected final CompositeMetadataHelper compositeMetadataHelper;
+    
+    protected final TypeFactory typeFactory = new TypeFactory();
     
     /**
      * Initializes the instance with a provided update interval.
@@ -731,7 +734,7 @@ public class AllFieldMetadataHelper {
      *             if the class is not accessible
      */
     protected Type<?> getDatatypeFromClass(Class<? extends Type<?>> datatypeClass) throws InstantiationException, IllegalAccessException {
-        return datatypeClass.newInstance();
+        return typeFactory.createType(datatypeClass.getName());
     }
     
     /**

--- a/src/main/java/datawave/query/util/MetadataHelper.java
+++ b/src/main/java/datawave/query/util/MetadataHelper.java
@@ -2030,4 +2030,19 @@ public class MetadataHelper {
         return metadataTableName;
     }
     
+    public int getTypeCacheSize() {
+        return allFieldMetadataHelper.getTypeCacheSize();
+    }
+    
+    public void setTypeCacheSize(int typeCacheSize) {
+        allFieldMetadataHelper.setTypeCacheSize(typeCacheSize);
+    }
+    
+    public int getTypeCacheExpirationInMinutes() {
+        return allFieldMetadataHelper.getTypeCacheExpirationInMinutes();
+    }
+    
+    public void setTypeCacheExpirationInMinutes(int typeCacheExpirationInMinutes) {
+        allFieldMetadataHelper.setTypeCacheExpirationInMinutes(typeCacheExpirationInMinutes);
+    }
 }

--- a/src/test/java/datawave/query/util/MetadataHelperTableTest.java
+++ b/src/test/java/datawave/query/util/MetadataHelperTableTest.java
@@ -2,7 +2,9 @@ package datawave.query.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -22,10 +24,12 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.NoSuchElementException;
 import java.util.Set;
+import java.util.TreeSet;
 
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.BatchWriterConfig;
+import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.iterators.LongCombiner;
@@ -181,9 +185,7 @@ public class MetadataHelperTableTest {
     @BeforeEach
     public void beforeEach() {
         allFieldHelper = createAllFieldMetadataHelper();
-        Set<Authorizations> userAuths = Collections.singleton(new Authorizations(authorizations));
-        Set<Authorizations> metadataAuths = Collections.singleton(new Authorizations(authorizations));
-        helper = new MetadataHelper(allFieldHelper, metadataAuths, client, METADATA_TABLE_NAME, userAuths, metadataAuths);
+        helper = createMetadataHelper(allFieldHelper);
     }
     
     private AllFieldMetadataHelper createAllFieldMetadataHelper() {
@@ -192,6 +194,16 @@ public class MetadataHelperTableTest {
         TypeMetadataHelper typeMetadataHelper = new TypeMetadataHelper(new HashMap<>(), auths, client, METADATA_TABLE_NAME, auths, false);
         CompositeMetadataHelper compositeMetadataHelper = new CompositeMetadataHelper(client, METADATA_TABLE_NAME, auths);
         return new AllFieldMetadataHelper(typeMetadataHelper, compositeMetadataHelper, client, METADATA_TABLE_NAME, auths, allAuths);
+    }
+    
+    private MetadataHelper createMetadataHelper(AllFieldMetadataHelper allFieldHelper) {
+        if (allFieldHelper == null) {
+            allFieldHelper = createAllFieldMetadataHelper();
+        }
+        
+        Set<Authorizations> userAuths = Collections.singleton(new Authorizations(authorizations));
+        Set<Authorizations> metadataAuths = Collections.singleton(new Authorizations(authorizations));
+        return new MetadataHelper(allFieldHelper, metadataAuths, client, METADATA_TABLE_NAME, userAuths, metadataAuths);
     }
     
     @Test
@@ -844,6 +856,31 @@ public class MetadataHelperTableTest {
         
         assertTrue(counts.containsKey("SHAPE"));
         assertEquals(536L, counts.get("SHAPE"));
+    }
+    
+    @Test
+    public void testInternalTypeCache() throws TableNotFoundException, InstantiationException, IllegalAccessException {
+        MetadataHelper helperWithDefaultCache = createMetadataHelper(null);
+        
+        // repeated calls to method that returns Types should return the same objects
+        Set<Type<?>> typesFirstCall = helperWithDefaultCache.getAllDatatypes();
+        Set<Type<?>> typesSecondCall = helperWithDefaultCache.getAllDatatypes();
+        
+        assertEquals(1, typesFirstCall.size());
+        assertEquals(1, typesSecondCall.size());
+        assertSame(typesFirstCall.iterator().next(), typesSecondCall.iterator().next());
+        
+        MetadataHelper helperWithConfiguredCache = createMetadataHelper(null);
+        helperWithConfiguredCache.setTypeCacheSize(1);
+        helperWithConfiguredCache.setTypeCacheExpirationInMinutes(0);
+        
+        // lowering the cache size and making repeated calls to methods that return Types should return different objects
+        typesFirstCall = helperWithConfiguredCache.getAllDatatypes();
+        typesSecondCall = helperWithConfiguredCache.getAllDatatypes();
+        
+        assertEquals(1, typesFirstCall.size());
+        assertEquals(1, typesSecondCall.size());
+        assertNotSame(typesFirstCall.iterator().next(), typesSecondCall.iterator().next());
     }
     
     /**


### PR DESCRIPTION
This should not be merged until https://github.com/NationalSecurityAgency/datawave-type-utils/pull/35 is integrated into a tag of type-utils.

The `getDatatypeFromClass` method is used in three locations, none of which require a new Type instance
- getAllDatatypes() -- ultimately returns a set of Types
- getFieldsToDatatypes() -- returns a multimap of Fields to Type, ultimately used to return a set of Types for a field
- MetadataHelper's getDatatypeFromClass(), which is just an unused wrapper method