### PR TITLE
Updating log message for empty reverse mapping

### DIFF
--- a/src/main/java/datawave/query/util/MetadataHelper.java
+++ b/src/main/java/datawave/query/util/MetadataHelper.java
@@ -538,7 +538,7 @@ public class MetadataHelper {
                 log.trace("empty query model for {}", this);
             }
             if ("DatawaveMetadata".equals(modelTableName)) {
-                log.error("Query Model should not be empty...");
+                log.warn("Query Model {} has no reverse mappings", modelName);
             }
         }
         


### PR DESCRIPTION
Changing log messages to not be so dire if query model does not find a reverse mapping - which may be totally normal.